### PR TITLE
Fix: a11y check

### DIFF
--- a/index.mk
+++ b/index.mk
@@ -32,7 +32,7 @@ APP_NAME = $(shell cat package.json 2>/dev/null | $(call JSON_GET_VALUE,name))
 DONE = echo ✓ $@ done
 CONFIG_VARS = curl -fsL https://ft-next-config-vars.herokuapp.com/$1/$(call APP_NAME)$(if $2,.$2,) -H "Authorization: `heroku config:get APIKEY --app ft-next-config-vars`"
 IS_USER_FACING = `find . -type d \( -path ./bower_components -o -path ./node_modules \) -prune -o -name '*.html' -print`
-MAKEFILE_HAS_A11Y = `grep -rli "make a11y" Makefile`
+MAKEFILE_HAS_A11Y = `grep -rli "a11y" Makefile`
 
 #
 # META TASKS


### PR DESCRIPTION
We're unlikely to find `make a11y` in our Makefiles as we don't put the make in.

removing the `make` should work just fine.