### PR TITLE
Align: pa11yci with n-Makefile

### DIFF
--- a/dotfiles/.pa11yci.js
+++ b/dotfiles/.pa11yci.js
@@ -1,9 +1,10 @@
+const extend = require('node.extend');
 const querystring = require('querystring');
 
 const viewports = process.env.PA11Y_VIEWPORTS || [
 	{
-		width: 1440,
-		height: 1220
+		width: 1280,
+		height: 800
 	}
 ];
 
@@ -32,6 +33,7 @@ const config = {
 			}
 		},
 		timeout: 50000,
+		wait: 300 || process.env.PA11Y_WAIT,
 		hideElements: 'iframe[src*=google],iframe[src*=proxy]',
 		rules: ['Principle1.Guideline1_3.1_3_1_AAA']
 	},
@@ -74,10 +76,6 @@ smoke.forEach((smokeConfig) => {
 
 		const thisUrl = {
 			url: process.env.TEST_URL + url
-		}
-
-		if (process.env.TEST_URL.includes('local')) {
-			thisUrl.screenCapture = './pa11y_screenCapture/' + url + '.png';
 		}
 
 		thisUrl.page = {};
@@ -138,10 +136,30 @@ smoke.forEach((smokeConfig) => {
 });
 
 for (let viewport of viewports) {
+
 	for (let url of urls) {
-		url.viewport = viewport;
-		config.urls.push(url);
+
+		const resultUrl = extend(true, {page: {viewport: viewport}}, url);
+
+		if (process.env.TEST_URL.includes('local')) {
+
+			const path = resultUrl.url.substring(resultUrl.url.lastIndexOf('/'));
+
+			let appFlags = 'no-flags';
+
+			if (resultUrl.page && resultUrl.page.headers) {
+				const flags = resultUrl.page.headers['FT-Flags'];
+				appFlags = flags.substring(0, flags.indexOf(DEFAULT_FLAGS) - 1);
+			}
+
+			resultUrl.screenCapture = `./pa11y_screenCapture/${viewport.width}x${viewport.height}/${appFlags}/${path || 'root'}.png`;
+
+		}
+
+		config.urls.push(resultUrl);
+
 	}
+
 }
 
 module.exports = config;


### PR DESCRIPTION
Adds [these n-Makefile changes](https://github.com/Financial-Times/n-makefile/pull/176) to `.pa11yci.js` that were included in `n-Makefile/config/.pa11yci.js` after `n-gage` had been created, meaning that until now they have not been included.

Soon we will hopefully only need to maintain the `n-gage` `pa11yci.js` file.