### PR TITLE
Override some .eslintrc.js properties via a repo’s package.json

### DIFF
--- a/dotfiles/.eslintrc.js
+++ b/dotfiles/.eslintrc.js
@@ -54,7 +54,7 @@ if (
 	});
 }
 
-if (packageJson.eslintConfig) {
+if (packageJson && packageJson.eslintConfig) {
 	Object.assign(config.env, packageJson.eslintConfig.env);
 	Object.assign(config.parserOptions, packageJson.eslintConfig.parserOptions);
 	Object.assign(config.rules, packageJson.eslintConfig.rules);


### PR DESCRIPTION
This conforms to the [ESLint conventions](http://eslint.org/docs/user-guide/configuring#configuration-file-formats) but allows us to override rules
(where normally ESLint will only use one config file per directory).

The intention is to slowly introduce new error rules per repo, without ruining
everyone’s flow. ✌️

(I’ll keep an eye on anyone abusing it… 👁 🔥 )