### PR TITLE
Make the squirrel check more forgiving?

### DIFF
--- a/scripts/squirrelify.js
+++ b/scripts/squirrelify.js
@@ -7,7 +7,7 @@ Add the following to your package.json
 "config": {
   "pre-git": {
     "pre-commit": [
-      "node_modules/.bin/secret-squirrel"
+      "secret-squirrel"
     ]
   }
 }


### PR DESCRIPTION
It currently doesn’t allow the pre-commit value to just be `secret-squirrel`, like it is in [next-myft-page](https://github.com/Financial-Times/next-myft-page/blob/master/package.json#L79).