### PR TITLE
fix fixable eslint things

### DIFF
--- a/index.mk
+++ b/index.mk
@@ -210,7 +210,7 @@ vault-cli:
 # VERIFY SUB-TASKS
 
 _verify_eslint:
-	@if [ -e .eslintrc.js ]; then $(call GLOB,'*.js') | xargs eslint --ignore-pattern '!' && $(DONE); fi
+	@if [ -e .eslintrc.js ]; then $(call GLOB,'*.js') | xargs eslint --fix --ignore-pattern '!' && $(DONE); fi
 
 _verify_lintspaces:
 	@if [ -e .editorconfig ] && [ -e package.json ]; then $(call GLOB) | xargs lintspaces -e .editorconfig -i js-comments -i html-comments && $(DONE); fi


### PR DESCRIPTION
This should just fix fixable eslint rules such as adding semicolons where necessary reducing failed builds. 