### PR TITLE
no quotes in variable setting

### DIFF
--- a/index.mk
+++ b/index.mk
@@ -23,9 +23,9 @@ export PATH := ./node_modules/.bin:$(PATH)
 SHELL := /bin/bash
 
 ifeq ("$(wildcard node_modules/@financial-times/n-gage/index.mk)","")
-PATH_TO_NGAGE := ""
+PATH_TO_NGAGE := 
 else
-PATH_TO_NGAGE := "node_modules/@financial-times/n-gage/"
+PATH_TO_NGAGE := node_modules/@financial-times/n-gage/
 endif
 
 # verify that githooks are configured correctly


### PR DESCRIPTION
problem:

```
$ make .env
node "node_modules/@financial-times/n-gage/"scripts/env-vault.js ft-next-article-email-api
```

see the double quotes in the command?