### PR TITLE
better error handling for env-vault

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,15 +19,14 @@
   },
   "homepage": "https://github.com/Financial-Times/n-gage#readme",
   "dependencies": {
+    "@financial-times/n-fetch": "^1.0.0-beta.4",
     "@financial-times/secret-squirrel": "^2.5.7",
     "husky": "^0.13.4",
     "jsonfile": "^3.0.0"
   },
   "devDependencies": {
-    "@financial-times/n-fetch": "^1.0.0-beta.4",
     "chai": "^4.0.2",
     "mocha": "^3.4.2",
-    "node-fetch": "^1.7.1",
     "npm-prepublish": "^1.2.2",
     "proxyquire": "^1.8.0",
     "sinon": "^2.3.6",

--- a/scripts/env-vault.js
+++ b/scripts/env-vault.js
@@ -1,4 +1,4 @@
-const fetch = require('node-fetch');
+const fetch = require('@financial-times/n-fetch');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
@@ -7,7 +7,6 @@ const app = process.argv[2].replace(/^ft-/, '');
 const token = fs.readFileSync(path.join(os.homedir(), '.vault-token'), { encoding: 'utf8' });
 
 const vault = path => fetch('https://vault.in.ft.com/v1/' + path, { headers: { 'X-Vault-Token': token } })
-    .then(res => res.json())
     .then(json => json.data || {});
 
 Promise.all([


### PR DESCRIPTION
instead of:

```
$ make .env
node node_modules/@financial-times/n-gage/scripts/env-vault.js ft-next-article-email-api
(node:95149) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): TypeError: Cannot read property 'reduce' of undefined
✓ .env-vault done
```

get:

```
$ make .env
node node_modules/@financial-times/n-gage/scripts/env-vault.js ft-next-article-email-api
event=N_FETCH_ERROR input=https://vault.in.ft.com/v1/secret/teams/next/next-article-email-api/shared statusCode=403 statusText=Forbidden level=warn
(node:95330) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): ForbiddenError: {"errors":["permission denied"]}
```