### PR TITLE
Continue to fetch .env vars from vault, even if the app has no shared secrets.

### DIFF
--- a/scripts/env-vault.js
+++ b/scripts/env-vault.js
@@ -7,21 +7,25 @@ const app = process.argv[2].replace(/^ft-/, '');
 const token = fs.readFileSync(path.join(os.homedir(), '.vault-token'), { encoding: 'utf8' });
 
 const vault = path => fetch('https://vault.in.ft.com/v1/' + path, { headers: { 'X-Vault-Token': token } })
-    .then(json => json.data || {});
+    .then(json => json.data || {})
+    .catch(error => {
+        console.error(`Error fetching ${path}`);
+        return true;
+    })
 
 Promise.all([
     vault(`secret/teams/next/${app}/development`),
     vault(`secret/teams/next/${app}/shared`),
     vault('secret/teams/next/shared/development'),
 ])
-    .then(([app, appShared, envShared]) => {        
-        const shared = appShared.env.reduce((keys, key) => {
+    .then(([app, appShared, envShared]) => {
+        const shared = appShared.env && appShared.env.reduce((keys, key) => {
             if (key in envShared) {
                 keys[key] = envShared[key];
             }
-            
+
             return keys;
-        }, {});
+        }, {}) || {};
 
         const keys = Object.assign({}, shared, app);
 


### PR DESCRIPTION
…  🐿2.5.9