### PR TITLE
Catch failing vault fetch

### DIFF
--- a/scripts/get-config.js
+++ b/scripts/get-config.js
@@ -101,18 +101,18 @@ module.exports = () => {
 	getToken()
 		.then(token => {
 			return Promise.all(getVaultPaths(opts.app, opts.env, opts.team).map(path => {
-        const url = 'https://vault.in.ft.com/v1/' + path;
+				const url = 'https://vault.in.ft.com/v1/' + path;
 
 				const vaultFetch = fetch(url, { headers: { 'X-Vault-Token': token } })
 				        .then(json => json.data || {});
 
 				if (opts.env === 'dev') {
-					vaultFetch.catch(err => {
+					return vaultFetch.catch(err => {
 						console.warn(`Couldn't get config at ${url}.`);
 					});
+				} else {
+					return vaultFetch;
 				}
-
-				return vaultFetch;
 			}))
 				.then(([app, appShared, envShared]) => parseKeys(app, appShared, envShared))
 				.then((keys) => appendSessionTokens(keys))


### PR DESCRIPTION
This was breaking `make .env` steps for anything that didn't have any `development` (for example) config set up in vault.