### PR TITLE
Check TEAM has length before passing to `get-config`

### DIFF
--- a/index.mk
+++ b/index.mk
@@ -189,7 +189,7 @@ endif
 	@if [[ $(shell grep --count *.env* .gitignore) -eq 0 ]]; then (echo $(ENV_MSG_IGNORE_ENV) && exit 1); fi
 	@if [ ! -e package.json ]; then (echo $(ENV_MSG_PACKAGE_JSON) && exit 1); fi
 	@if [ ! -z $(CIRCLECI) ]; then (echo $(ENV_MSG_CIRCLECI) && exit 1); fi
-	@ngage get-config --team $(TEAM)
+	@if [ ! -z "$(TEAM)"]; then (ngage get-config --team $(TEAM)); else (ngage get-config); fi
 	@$(DONE)
 
 # for use with CI deployments that need the env vars in a file (dotenv format)


### PR DESCRIPTION
Makefile was running `get-config --team `
This overrode the yargs default, resulting in the vars were being fetched from the wrong place.
 🐿 v2.5.16