### PR TITLE
Restore sanity to EditorConfig

### DIFF
--- a/dotfiles/.editorconfig
+++ b/dotfiles/.editorconfig
@@ -1,7 +1,16 @@
 root = true
 
-[**{.js,.ts,.html,.hbs,.mustache,.xml,.xsl,.scss,.css,.sh,.vcl,.mk,Makefile,.json,.yml,.yaml,.md}]
-end_of_line = lf
-insert_final_newline = true
+[**{.js,.ts,.html,.hbs,.mustache,.xml,.xsl,.scss,.css,.sh,.vcl,.mk,Makefile,.md}]
 charset = utf-8
+end_of_line = lf
+indent_style = tab
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[**{.json,.yml,.yaml}]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
 trim_trailing_whitespace = true


### PR DESCRIPTION
Brings back tab enforcement for most files (with a 2 space rule for yml, yaml, json)

_Breathes a sigh of relief_ That’s better. ✌️