### PR TITLE
Add default smoke test task

### DIFF
--- a/index.mk
+++ b/index.mk
@@ -101,6 +101,17 @@ buil%: public/__about.json
 	@if [ -e Procfile ] && [ "$(findstring build-production,$@)" == "build-production" ]; then haikro build; fi
 	@$(DONE)
 
+smok%:
+ifneq ($(CIRCLE_BRANCH),)
+	TEST_URL=${TEST_APP}; \
+	echo ${TEST_APP} | grep http -s || TEST_URL=http://${TEST_APP}.herokuapp.com; \
+	n-test smoke -H $$TEST_URL;
+else
+	@if [ -z "$(TEST_URL)" ]; then TEST_URL=local.ft.com:3002; fi; \
+	n-test smoke -H $$TEST_URL;
+endif
+	@$(DONE)
+
 watc%: ## watch: Watch for static asset changes.
 	@if [ -e webpack.config.js ]; then webpack --watch --debug; fi
 	@$(DONE)


### PR DESCRIPTION
I don't _think_ this actually gets run on CI (it's part of one of the nht deploy tasks), but this standardises `make smoke` across apps, and removes the need for `test-smoke-local`.

The only reason to override this would be if your app runs locally on https.

@jonnywyatt can do a similar one for cypress, or wait for an established pattern across apps/components?