### PR TITLE
Update suggested vault command

### DIFF
--- a/index.mk
+++ b/index.mk
@@ -171,7 +171,7 @@ ENV_MSG_IGNORE_ENV =
 # Environment variables come from https://github.com/Financial-Times/next-vault-sync
 .env:
 	@if [[ -z "$(shell command -v vault)" ]]; then echo "Error: You don't have Vault installed. Follow the guide at https://github.com/Financial-Times/vault/wiki/Getting-Started"; exit 1; fi
-	@if [[ -z "$(shell find ~/.vault-token -mmin -480)" ]]; then echo "Error: You are not logged into Vault. Try vault auth --method github."; exit 1; fi
+	@if [[ -z "$(shell find ~/.vault-token -mmin -480)" ]]; then echo "Error: You are not logged into Vault. Try vault login --method github."; exit 1; fi
 	@if [[ -z "$(shell grep *.env* .gitignore)" ]]; then echo "Error: .gitignore must include: *.env* (including the asterisks)"; exit 1; fi
 	@if [[ ! -e package.json ]]; then echo "Error: package.json not found."; exit 1; fi
 	@if [[ ! -z "$(CIRCLECI)" ]]; then echo "Error: The CIRCLECI environment variable must *not* be set."; exit 1; fi


### PR DESCRIPTION
> WARNING! The "vault auth ARG" command is deprecated and is now a subcommand
> for interacting with auth methods. To authenticate locally to Vault, use
> "vault login" instead. This backwards compatability will be removed in Vault
> 0.11 (or later).

<!-- mama we're all gonna die -->