### PR TITLE
Quote .gitignore grep pattern as it contains wildcard characters

### DIFF
--- a/index.mk
+++ b/index.mk
@@ -172,7 +172,7 @@ ENV_MSG_IGNORE_ENV =
 .env:
 	@if [[ -z "$(shell command -v vault)" ]]; then echo "Error: You don't have Vault installed. Follow the guide at https://github.com/Financial-Times/vault/wiki/Getting-Started"; exit 1; fi
 	@if [[ -z "$(shell find ~/.vault-token -mmin -480)" ]]; then echo "Error: You are not logged into Vault. Try vault login --method github."; exit 1; fi
-	@if [[ -z "$(shell grep *.env* .gitignore)" ]]; then echo "Error: .gitignore must include: *.env* (including the asterisks)"; exit 1; fi
+	@if [[ -z "$(shell grep '*.env*' .gitignore)" ]]; then echo "Error: .gitignore must include: *.env* (including the asterisks)"; exit 1; fi
 	@if [[ ! -e package.json ]]; then echo "Error: package.json not found."; exit 1; fi
 	@if [[ ! -z "$(CIRCLECI)" ]]; then echo "Error: The CIRCLECI environment variable must *not* be set."; exit 1; fi
 


### PR DESCRIPTION
In some developers' shells, this was causing `make .env` to fail.

Fixes issue #115