### PR TITLE
Viewports in pa11y have to be integers

### DIFF
--- a/dotfiles/.pa11yci.js
+++ b/dotfiles/.pa11yci.js
@@ -12,7 +12,7 @@ const parseEnvironmentViewPort = (viewportStr) => {
 		return null;
 	}
 
-	return {width:result[1],height:result[2]};
+	return {width: Number(result[1]), height: Number(result[2])};
 };
 
 const parseEnvironmentViewPorts = (env) => {


### PR DESCRIPTION
Came up in next-retention which specifies viewports in it's environment variables. https://circleci.com/gh/Financial-Times/next-retention/1637