### PR TITLE
Allow nightly build to deploy during office hours

### DIFF
--- a/index.mk
+++ b/index.mk
@@ -266,6 +266,8 @@ hel%: ## help: Show this help message.
 # If a nightly build is triggered during the day, we want it to deploy since it is a rerun build!
 # CircleCI runs in UTC, so give an hour leeway each way.
 
+HOUR = $(shell date +%H)
+
 deploy-by-day:
 ifeq ($(FT_NIGHTLY_BUILD),)
 	$(MAKE) deploy


### PR DESCRIPTION
 🐿 v2.7.0

We keep rebuilding nightly builds thinking they've deployed, but they don't.

CircleCI (v1 at least) makes it hard to know that it's a nightly build.

This change allows `deploy-by-day` to deploy during the day (defined as 8am to 7pm, since CircleCI seems to run on UTC), even if `FT_NIGHTLY_BUILD=true`