### PR TITLE
Allow eslint settings to be overridden

### DIFF
--- a/dotfiles/.eslintrc.js
+++ b/dotfiles/.eslintrc.js
@@ -51,7 +51,8 @@ const config = {
 				'no-only-tests/no-only-tests': 2
 			}
 		}
-	]
+	],
+	'settings' : {}
 };
 
 const packageJson = require('./package.json');
@@ -85,6 +86,7 @@ if (packageJson && packageJson.eslintConfig) {
 	Object.assign(config.parserOptions, packageJson.eslintConfig.parserOptions);
 	Object.assign(config.rules, packageJson.eslintConfig.rules);
 	Object.assign(config.globals, packageJson.eslintConfig.globals);
+	Object.assign(config.settings, packageJson.eslintConfig.settings);
 }
 
 module.exports = config;


### PR DESCRIPTION
This looks to address a linting issue we're having in next-video-editor. We're on `react@15.4.1` but the  react eslint plugin lints against the latest stable version (16). You can however specify react version in `estlintconfig.settings.react`.

This change allows `estlintconfig.settings`to be configured via package.json.