### PR TITLE
Eslint upgrade to v5.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@financial-times/n-fetch": "^1.0.0-beta.4",
     "@financial-times/secret-squirrel": "^2.6.0",
-    "eslint": "^4.14.0",
+    "eslint": "^5.4.0",
     "eslint-plugin-no-only-tests": "^2.0.0",
     "husky": "^0.14.3",
     "jsonfile": "^4.0.0",


### PR DESCRIPTION
 🐿 v2.10.2

Eslint complains about React shorthand for fragments `<> </>`. The problem has been fixed in `eslint v5.x` but `n-gage` is using `v4.x`. see https://github.com/eslint/eslint/issues/9662

This upgrades to v5.4.0. It does have breaking changes. 

The following warning appears when running v5.4.0 on N-ui, Next-myst-client, N-hanelbars, N-flags-client:

`(node:24106) [ESLINT_LEGACY_OBJECT_REST_SPREAD] DeprecationWarning: The 'parserOptions.ecmaFeatures.experimentalObjectRestSpread' option is deprecated. Use 'parserOptions.ecmaVersion' instead. (found in ".eslintrc.js")`




 