### PR TITLE
show help by default (i.e. running make without any arguments)

### DIFF
--- a/index.mk
+++ b/index.mk
@@ -47,6 +47,9 @@ IS_USER_FACING = `find . -type d \( -path ./bower_components -o -path ./node_mod
 MAKEFILE_HAS_A11Y = `grep -rli "a11y" Makefile`
 REPLACE_IN_GITIGNORE = sed -i -e 's/$1/$2/g' .gitignore && rm -f .gitignore-e ||:
 
+# Show help when run without any target
+.DEFAULT_GOAL := help
+
 #
 # META TASKS
 #


### PR DESCRIPTION
technically a breaking change, although currently what happens is make outputs the monumentally unhelpful `make: Nothing to be done for 'ci-n-ui-check'.`