### PR TITLE
use an actual prerequisite to make serverless function subfolders

### DIFF
--- a/index.mk
+++ b/index.mk
@@ -1,3 +1,4 @@
+$(info local)
 # find out where we are so we can include things relatively. MAKEFILE_LIST is the list
 # of all included makefiles; this makefile will be the most recent one
 this-makefile = $(realpath $(lastword $(MAKEFILE_LIST)))

--- a/src/tasks/install.mk
+++ b/src/tasks/install.mk
@@ -1,6 +1,8 @@
+FUNCTIONS_NPM_FOLDERS = $(wildcard functions/*/node_modules)
+FUNCTIONS_BOWER_FOLDERS = $(wildcard functions/*/bower_components)
+
 instal%: ## install: Setup this repository.
-instal%: node_modules bower_components stylelint-transition .editorconfig .eslintrc.js .stylelintrc .pa11yci.js
-	$(MAKE) $(foreach f, $(shell find functions/* -type d -maxdepth 0 2>/dev/null), $f/node_modules $f/bower_components)
+instal%: node_modules bower_components stylelint-transition .editorconfig .eslintrc.js .stylelintrc .pa11yci.js $(FUNCTIONS_NPM_FOLDERS) $(FUNCTIONS_BOWER_FOLDERS)
 	@$(DONE)
 	@if [ -z $(CIRCLECI) ] && [ ! -e .env ]; then (echo "Note: If this is a development environment, you will likely need to import the project's environment variables by running 'make .env'."); fi
 

--- a/src/tasks/install.mk
+++ b/src/tasks/install.mk
@@ -1,5 +1,7 @@
-FUNCTIONS_NPM_FOLDERS = $(wildcard functions/*/node_modules)
-FUNCTIONS_BOWER_FOLDERS = $(wildcard functions/*/bower_components)
+FUNCTIONS_PACKAGE_JSONS = $(wildcard functions/*/package.json)
+FUNCTIONS_NPM_FOLDERS = $(patsubst functions/%/package.json, functions/%/node_modules, $(FUNCTIONS_PACKAGE_JSONS))
+FUNCTIONS_BOWER_JSONS = $(wildcard functions/*/bower_components)
+FUNCTIONS_BOWER_FOLDERS = $(patsubst functions/%/bower.json, functions/%/bower_components, $(FUNCTIONS_BOWER_JSONS))
 
 instal%: ## install: Setup this repository.
 instal%: node_modules bower_components stylelint-transition .editorconfig .eslintrc.js .stylelintrc .pa11yci.js $(FUNCTIONS_NPM_FOLDERS) $(FUNCTIONS_BOWER_FOLDERS)

--- a/src/tasks/install.mk
+++ b/src/tasks/install.mk
@@ -3,6 +3,9 @@ FUNCTIONS_NPM_FOLDERS = $(patsubst functions/%/package.json, functions/%/node_mo
 FUNCTIONS_BOWER_JSONS = $(wildcard functions/*/bower_components)
 FUNCTIONS_BOWER_FOLDERS = $(patsubst functions/%/bower.json, functions/%/bower_components, $(FUNCTIONS_BOWER_JSONS))
 
+# tell make not to delete these folders (it thinks they're intermediate dependencies and it's sort of right but actually not)
+.PRECIOUS: $(FUNCTIONS_NPM_FOLDERS) $(FUNCTIONS_BOWER_FOLDERS)
+
 instal%: ## install: Setup this repository.
 instal%: node_modules bower_components stylelint-transition .editorconfig .eslintrc.js .stylelintrc .pa11yci.js $(FUNCTIONS_NPM_FOLDERS) $(FUNCTIONS_BOWER_FOLDERS)
 	@$(DONE)

--- a/src/tasks/install.mk
+++ b/src/tasks/install.mk
@@ -14,25 +14,27 @@ instal%: node_modules bower_components stylelint-transition .editorconfig .eslin
 # INSTALL SUB-TASKS
 
 # Regular npm install
-node_modules: package.json
-	@if [ -e package-lock.json ]; then rm package-lock.json; fi
-	@if [ -e package.json ]; then $(NPM_INSTALL) && $(DONE); fi
+%/node_modules: %/package.json
+	cd $(@D)
+	if [ -e package-lock.json ]; then rm package-lock.json; fi
+	if [ -e package.json ]; then $(NPM_INSTALL) && $(DONE); fi
 
 # Regular bower install
-bower_components: bower.json
-	@if [ -e bower.json ]; then $(BOWER_INSTALL) && $(DONE); fi
+%/bower_components: bower.json
+	cd $(@D)
+	if [ -e bower.json ]; then $(BOWER_INSTALL) && $(DONE); fi
 
 # These tasks have been intentionally left blank
-package.json:
-bower.json:
+%/package.json:
+%/bower.json:
 
 # node_modules for Lambda functions
-functions/%/node_modules:
-	@cd $(dir $@) && if [ -e package.json ]; then $(NPM_INSTALL) && $(DONE); fi
-
-# bower_components for Lambda functions
-functions/%/bower_components:
-	@cd $(dir $@) && if [ -e bower.json ]; then $(BOWER_INSTALL) && $(DONE); fi
+# functions/%/node_modules:
+# 	cd $(dir $@) && if [ -e package.json ]; then $(NPM_INSTALL) && $(DONE); fi
+#
+# # bower_components for Lambda functions
+# functions/%/bower_components:
+# 	cd $(dir $@) && if [ -e bower.json ]; then $(BOWER_INSTALL) && $(DONE); fi
 
 # Manage various dot/config files if they're in the .gitignore
 .editorconfig .eslintrc.js .stylelintrc .pa11yci.js:


### PR DESCRIPTION
ever wonder what this line meant at the bottom of `make install`'s output?

<img width="567" alt="screen shot 2018-10-04 at 15 53 23" src="https://user-images.githubusercontent.com/631757/46483103-ccfbd480-c7ee-11e8-96b0-a5329519bdc2.png">

no, me neither.

so, on serverless projects, `make install` recurses into the `functions` folders and installs their `node_modules` & `bower_components`, by doing this:

```make
instal%: node_modules bower_components stylelint-transition .editorconfig .eslintrc.js .stylelintrc .pa11yci.js
	@$(MAKE) $(foreach f, $(shell find functions/* -type d -maxdepth 0 2>/dev/null), $f/node_modules $f/bower_components)
```

if there _are_ no `functions` folders, i.e. 99% of next repos, that `$(foreach)` outputs an empty string, and this just runs `make`. usually this runs the first concrete target in `Makefile`, which is (almost?) always the bootstrap `index.mk` target. hence the output above. and because we were silencing the command printing (`@` at the start of the line) this was just some innocuous output and we had no idea where it came from.

but since #133 that's not the default task any more. it's `help`. which uses `columns` to format its output. which isn't installed on CI. sorry i broke all your builds lol

lessons:

1. there's no good reason to silence command printing apart from like `echo`
2. use prerequisites for things. it's what make is for
3. if you expect something is going to be a breaking change even just "technically" lol don't bloody release it _**bren**_