### PR TITLE
Fix vault error message parsing

### DIFF
--- a/src/tasks/env.mk
+++ b/src/tasks/env.mk
@@ -2,7 +2,7 @@
 # Environment variables come from https://github.com/Financial-Times/next-vault-sync
 .env:
 	@if [[ -z "$(shell command -v vault)" ]]; then echo "Error: You don't have Vault installed. Follow the guide at https://github.com/Financial-Times/vault/wiki/Getting-Started"; exit 1; fi
-	@if [[ -z "$(shell find ~/.vault-token -mmin -480)" ]]; then echo "Error: You are not logged into Vault. Try vault login --method github token=\$VAULT_AUTH_GITHUB_TOKEN"; exit 1; fi
+	@if [[ -z "$(shell find ~/.vault-token -mmin -480)" ]]; then echo 'Error: You are not logged into Vault. Try vault login --method github token=$$VAULT_AUTH_GITHUB_TOKEN'; exit 1; fi
 	@if [[ -z "$(shell grep '*.env*' .gitignore)" ]]; then echo "Error: .gitignore must include: *.env* (including the asterisks)"; exit 1; fi
 	@if [[ ! -e package.json ]]; then echo "Error: package.json not found."; exit 1; fi
 	@if [[ ! -z "$(CIRCLECI)" ]]; then echo "Error: The CIRCLECI environment variable must *not* be set."; exit 1; fi


### PR DESCRIPTION
The make file doesn't use bash but sh, which parses env vars differently. To
escape the envvar VAULT_AUTH_GITHUB_TOKEN in sh, we need to use single quotes
for the string, and a double dollar sign before the name of the envvar. This
will stop the value of the env var getting displayed in the terminal after the
user has copy/pasted it.