### PR TITLE
Revert test-review-app being able to be overridden

### DIFF
--- a/src/tasks/review-app.mk
+++ b/src/tasks/review-app.mk
@@ -15,4 +15,4 @@ review-app: tidy-review-app .review-app
 gtg-review-app: review-app
 	nht gtg $(REVIEW_APP)
 
-test-review-ap%: gtg-review-app smoke a11y
+test-review-app: gtg-review-app smoke a11y


### PR DESCRIPTION
`test-review-app` target is not working for default use case

See https://financialtimes.slack.com/archives/C08PF33EC/p1544106920019000

Fix for now until we find a better way.