### PR TITLE
Move `test-review-app` dependencies into target

### DIFF
--- a/src/tasks/review-app.mk
+++ b/src/tasks/review-app.mk
@@ -15,4 +15,5 @@ review-app: tidy-review-app .review-app
 gtg-review-app: review-app
 	nht gtg $(REVIEW_APP)
 
-test-review-app: gtg-review-app smoke a11y
+test-review-ap%:
+	make gtg-review-app && make smoke && make a11y


### PR DESCRIPTION
Fix problem with [v3.0.0-beta.18](https://github.com/Financial-Times/n-gage/releases/tag/v3.0.0-beta.18).

To allow behaviour in https://github.com/Financial-Times/next/issues/274

## Explanation

If you want to wildcard `n-gage` targets, and the targets have dependencies (eg, `test-review-ap%: gtg-review-app smoke a11y`), it requires that the local `Makefile` implements the target (ie, `test-review-app` from the previous example). Otherwise the local `Makefile` will fail

	$ make test-review-app
	make: *** No rule to make target `test-review-app'.  Stop.

If you don't want to require the local `Makefile` implement the target (allow it to be optional), don't have dependencies in the wildcard target ie, for the previous example

	# n-gage
	test-review-ap%:
		make gtg-review-app && make smoke && make a11y

For no reference to `test-review-app` in `Makefile`
	
	$ make test-review-app
	[Runs n-gage `test-review-ap%` target...]

For a `Makefile` with

	test-review-app:
		echo "Hello"

Output

	$ make test-review-app
	echo "Hello"
	Hello
