### PR TITLE
Allow test review app to be overridden (3rd time lucky)

### DIFF
--- a/src/setup.mk
+++ b/src/setup.mk
@@ -84,17 +84,6 @@ ASSERT_ANY_VAR_EXISTS = $(if $(findstring $(call _SORT_VARS_LIST,$1),$(call _MIS
 # the review app on heroku
 REVIEW_APP=$(shell cat .review-app)
 
-# url to smoke/a11y test. prefer test url set externally
-ifndef TEST_URL
-TEST_URL = $(if $(CIRCLE_BRANCH),\
-  http://$(REVIEW_APP).herokuapp.com,\
-  https://local.ft.com:5050\
-)
-endif
-
-# exported for pa11y-ci's benefit
-export TEST_URL
-
 #
 # META TASKS
 # (specially-named targets that enable certain Make behaviour)

--- a/src/setup.mk
+++ b/src/setup.mk
@@ -78,12 +78,6 @@ ASSERT_ANY_VAR_EXISTS = $(if $(findstring $(call _SORT_VARS_LIST,$1),$(call _MIS
   $(call ERROR, $(call COLOR, At least one of the variables {cyan $(strip $1)} must be defined in your Makefile))\
 )
 
-# functions for testing review or local apps
-
-# this file is created by the `review-app` task. if it exists it contains the name of
-# the review app on heroku
-REVIEW_APP=$(shell cat .review-app)
-
 #
 # META TASKS
 # (specially-named targets that enable certain Make behaviour)

--- a/src/tasks/review-app.mk
+++ b/src/tasks/review-app.mk
@@ -16,6 +16,6 @@ gtg-review-app: review-app
 	nht gtg $(REVIEW_APP)
 
 test-review-ap%:
-	make gtg-review-app
-	make smoke
-	make a11y
+	$(MAKE) gtg-review-app
+	$(MAKE) smoke
+	$(MAKE) a11y

--- a/src/tasks/review-app.mk
+++ b/src/tasks/review-app.mk
@@ -17,5 +17,6 @@ gtg-review-app: review-app
 
 test-review-ap%:
 	$(MAKE) gtg-review-app
-	$(MAKE) smoke
+	TEST_URL="http://$$(cat .review-app).herokuapp.com" \
+		$(MAKE) smoke
 	$(MAKE) a11y

--- a/src/tasks/review-app.mk
+++ b/src/tasks/review-app.mk
@@ -15,8 +15,7 @@ review-app: tidy-review-app .review-app
 gtg-review-app: review-app
 	nht gtg $(REVIEW_APP)
 
-run-test-review-app: gtg-review-app
-	$(MAKE) smoke a11y
-
 test-review-ap%:
-	$(MAKE) run-test-review-app
+	$(MAKE) gtg-review-app
+	TEST_URL="http://$$(cat .review-app).herokuapp.com" \
+		$(MAKE) smoke a11y

--- a/src/tasks/review-app.mk
+++ b/src/tasks/review-app.mk
@@ -24,3 +24,4 @@ test-review-ap%: # test-review-app: create and test a review app on heroku
 	$(MAKE) gtg-review-app
 	TEST_URL="http://$$(cat $(REVIEW_APP_FILE)).herokuapp.com" \
 		$(MAKE) smoke a11y
+	@$(DONE)

--- a/src/tasks/review-app.mk
+++ b/src/tasks/review-app.mk
@@ -15,7 +15,8 @@ review-app: tidy-review-app .review-app
 gtg-review-app: review-app
 	nht gtg $(REVIEW_APP)
 
+run-test-review-app: gtg-review-app
+	$(MAKE) smoke a11y
+
 test-review-ap%:
-	$(MAKE) gtg-review-app
-	TEST_URL="http://$$(cat .review-app).herokuapp.com" \
-		$(MAKE) smoke a11y
+	$(MAKE) run-test-review-app

--- a/src/tasks/review-app.mk
+++ b/src/tasks/review-app.mk
@@ -1,5 +1,10 @@
+# this file is created by the `review-app` task. 
+# if it exists it contains the name of the review app
+# on heroku
+REVIEW_APP_FILE := .review-app
+
 tidy-review-app:
-	-rm .review-app
+	-rm $(REVIEW_APP_FILE)
 
 review-app: tidy-review-app .review-app
 
@@ -13,9 +18,9 @@ review-app: tidy-review-app .review-app
 		--github-token $(GITHUB_AUTH_TOKEN) > $@
 
 gtg-review-app: review-app
-	nht gtg $(REVIEW_APP)
+	nht gtg $$(cat $(REVIEW_APP_FILE))
 
-test-review-ap%:
+test-review-ap%: # test-review-app: create and test a review app on heroku
 	$(MAKE) gtg-review-app
-	TEST_URL="http://$$(cat .review-app).herokuapp.com" \
+	TEST_URL="http://$$(cat $(REVIEW_APP_FILE)).herokuapp.com" \
 		$(MAKE) smoke a11y

--- a/src/tasks/review-app.mk
+++ b/src/tasks/review-app.mk
@@ -18,5 +18,4 @@ gtg-review-app: review-app
 test-review-ap%:
 	$(MAKE) gtg-review-app
 	TEST_URL="http://$$(cat .review-app).herokuapp.com" \
-		$(MAKE) smoke
-	$(MAKE) a11y
+		$(MAKE) smoke a11y


### PR DESCRIPTION
Attempt no. 3 😬

Previously with [v3.0.0-beta.21](https://github.com/Financial-Times/n-gage/releases/tag/v3.0.0-beta.21), it would fail on the smoke tests because the `TEST_URL` variable would not be set. This is because it gets evaluated before it is run, and doesn't get updated even though the `gtg-review-app` generates it.

To fix this, I've removed the `REVIEW_APP` variable, and replaced it with just the `REVIEW_APP_FILE`. If the value of the review app name is required, the `REVIEW_APP_FILE` needs to be explicitly called with `cat` to get it. This gets evaluated inline so it is clear when you get the values.

`TEST_URL` is also explicitly set before calling `smoke` and `a11y` targets. The previous way of setting `TEST_URL` has been removed as well, to make sure it is more explicit when it is set. @quarterto do you think this is alright?

Also did some clean up:

* Move review app variable into its file
* Call `@$(DONE)` when done as per the convention of the other targets
* Add more comments

Hopefully this will be the final fix for this!

Working CI example: https://circleci.com/gh/Financial-Times/next-syndication-api/1577