### PR TITLE
Allow override variable for overriding configure

### DIFF
--- a/src/tasks/review-app.mk
+++ b/src/tasks/review-app.mk
@@ -10,6 +10,7 @@ review-app: tidy-review-app .review-app
 
 .review-app:
 	@echo 'Creating review app for $(VAULT_NAME)'
+	@echo 'REVIEW_APP_CONFIGURE_OVERRIDES = $(REVIEW_APP_CONFIGURE_OVERRIDES)'
 ifdef REVIEW_APP_CONFIGURE_OVERRIDES
 	@echo 'Using nht configure overrides: $(REVIEW_APP_CONFIGURE_OVERRIDES)'
 	nht configure $(VAULT_NAME) review-app --overrides "$(REVIEW_APP_CONFIGURE_OVERRIDES)"

--- a/src/tasks/review-app.mk
+++ b/src/tasks/review-app.mk
@@ -10,13 +10,11 @@ review-app: tidy-review-app .review-app
 
 .review-app:
 	@echo 'Creating review app for $(VAULT_NAME)'
-	@echo 'REVIEW_APP_CONFIGURE_OVERRIDES = $(REVIEW_APP_CONFIGURE_OVERRIDES)'
-ifdef REVIEW_APP_CONFIGURE_OVERRIDES
-	@echo 'Using nht configure overrides: $(REVIEW_APP_CONFIGURE_OVERRIDES)'
-	nht configure $(VAULT_NAME) review-app --overrides "$(REVIEW_APP_CONFIGURE_OVERRIDES)"
-else
-	nht configure $(VAULT_NAME) review-app --overrides NODE_ENV=branch
-endif
+	$(if $(REVIEW_APP_CONFIGURE_OVERRIDES),\
+	  nht configure $(VAULT_NAME) review-app --overrides "$(REVIEW_APP_CONFIGURE_OVERRIDES)", \
+	  nht configure $(VAULT_NAME) review-app --overrides NODE_ENV=branch \
+	)
+
 	@nht review-app $(VAULT_NAME) \
 		--repo-name $(CIRCLE_PROJECT_REPONAME) \
 		--branch $(CIRCLE_BRANCH) \

--- a/src/tasks/review-app.mk
+++ b/src/tasks/review-app.mk
@@ -10,7 +10,9 @@ review-app: tidy-review-app .review-app
 
 .review-app:
 	@echo 'Creating review app for $(VAULT_NAME)'
-	nht configure $(VAULT_NAME) review-app --overrides NODE_ENV=branch
+	[ -z "$REVIEW_APP_CONFIGURE_OVERRIDES" ] \
+		&& nht configure $(VAULT_NAME) review-app --overrides NODE_ENV=branch || \
+		nht configure $(VAULT_NAME) review-app --overrides "$(REVIEW_APP_CONFIGURE_OVERRIDES)"
 	@nht review-app $(VAULT_NAME) \
 		--repo-name $(CIRCLE_PROJECT_REPONAME) \
 		--branch $(CIRCLE_BRANCH) \
@@ -20,7 +22,7 @@ review-app: tidy-review-app .review-app
 gtg-review-app: review-app
 	nht gtg $$(cat $(REVIEW_APP_FILE))
 
-test-review-ap%: # test-review-app: create and test a review app on heroku
+test-review-ap%: # test-review-app: create and test a review app on heroku. To override custom environment variables when running `nht configure`, add `REVIEW_APP_CONFIGURE_OVERRIDES="NODE_ENV=branch,OTHER_VAR=something" to the Makefile`
 	$(MAKE) gtg-review-app
 	TEST_URL="http://$$(cat $(REVIEW_APP_FILE)).herokuapp.com" \
 		$(MAKE) smoke a11y

--- a/src/tasks/review-app.mk
+++ b/src/tasks/review-app.mk
@@ -11,6 +11,7 @@ review-app: tidy-review-app .review-app
 .review-app:
 	@echo 'Creating review app for $(VAULT_NAME)'
 ifdef REVIEW_APP_CONFIGURE_OVERRIDES
+	@echo 'Using nht configure overrides: $(REVIEW_APP_CONFIGURE_OVERRIDES)'
 	nht configure $(VAULT_NAME) review-app --overrides "$(REVIEW_APP_CONFIGURE_OVERRIDES)"
 else
 	nht configure $(VAULT_NAME) review-app --overrides NODE_ENV=branch

--- a/src/tasks/review-app.mk
+++ b/src/tasks/review-app.mk
@@ -10,9 +10,11 @@ review-app: tidy-review-app .review-app
 
 .review-app:
 	@echo 'Creating review app for $(VAULT_NAME)'
-	[ -z "$REVIEW_APP_CONFIGURE_OVERRIDES" ] \
-		&& nht configure $(VAULT_NAME) review-app --overrides NODE_ENV=branch || \
-		nht configure $(VAULT_NAME) review-app --overrides "$(REVIEW_APP_CONFIGURE_OVERRIDES)"
+ifdef REVIEW_APP_CONFIGURE_OVERRIDES
+	nht configure $(VAULT_NAME) review-app --overrides "$(REVIEW_APP_CONFIGURE_OVERRIDES)"
+else
+	nht configure $(VAULT_NAME) review-app --overrides NODE_ENV=branch
+endif
 	@nht review-app $(VAULT_NAME) \
 		--repo-name $(CIRCLE_PROJECT_REPONAME) \
 		--branch $(CIRCLE_BRANCH) \


### PR DESCRIPTION
Add `REVIEW_APP_CONFIGURE_OVERRIDES` to override the override variable for nht configure

Fixes https://github.com/Financial-Times/next/issues/272

Example of it running: https://github.com/Financial-Times/next-myft-page/pull/1919#pullrequestreview-181293687