### PR TITLE
Use EU app scale by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ These variables should be declared in the `Makefile` to set up deployment tasks 
 | `HEROKU_APP_EU` | [Required] The main Heroku app or the EU Heroku app if it is a multi-region app eg, `ft-next-search-page-eu` for multi region or `ft-next-video-page` for single region |
 | `HEROKU_APP_US` | [Optional] The US Heroku app. Only needed if it is a multi region app |
 | `HEROKU_APP_CANARY` | [Optional] The canary Heroku app. Only needed if there is a canary app eg, `ft-next-preflight-canary` |
-| `HEROKU_APP_CANARY_SCALE` | Specify the number of dynos for the canary app. Only required if there is a canary app |
+| `HEROKU_APP_CANARY_SCALE` | [Optional] Canary apps only. Specify the number of web dynos for the canary app. If not specified, it will use the `HEROKU_APP_EU` scale configuration |
 | `REVIEW_APP_CONFIGURE_OVERRIDES` | [Optional] Override environment variables for the review apps. By default it is `NODE_ENV=branch`, so to add new ones add `REVIEW_APP_CONFIGURE_OVERRIDES="NODE_ENV=branch,OTHER_VAR=something"` |
 
 ## Bootstrapping

--- a/src/tasks/deploy.mk
+++ b/src/tasks/deploy.mk
@@ -42,7 +42,12 @@ deploy-canary: ## deploy-canary: deploy canary app to staging
 	nht configure $(VAULT_NAME) $(HEROKU_APP_CANARY) --overrides "FT_APP_VARIANT=canary" \
 
 	heroku pipelines:promote -a $(HEROKU_APP_STAGING) --to $(HEROKU_APP_CANARY)
-	heroku ps:scale web=$(HEROKU_APP_CANARY_SCALE) -a $(HEROKU_APP_CANARY)
+
+	# Scale up canary either based on the variable or the EU app
+	$(if $(HEROKU_APP_CANARY_SCALE),\
+	  heroku ps:scale web=$(HEROKU_APP_CANARY_SCALE) -a $(HEROKU_APP_CANARY), \
+	  heroku ps:scale $(shell heroku ps:scale -a $(HEROKU_APP_EU)) -a $(HEROKU_APP_CANARY) \
+	)
 	heroku dyno:scale web=0 -a $(HEROKU_APP_STAGING)
 
 deplo%: ## deploy: deploy the app to heroku


### PR DESCRIPTION
Since EU represents production, use this by default for canary scales 🐿 v2.11.0

Fixes https://github.com/Financial-Times/next/issues/308