### PR TITLE
Destroy review app if it passes tests on the master branch 🐿 v2.11.0

### DIFF
--- a/src/tasks/review-app.mk
+++ b/src/tasks/review-app.mk
@@ -28,4 +28,8 @@ test-review-ap%: # test-review-app: create and test a review app on heroku. To o
 	$(MAKE) gtg-review-app
 	TEST_URL="http://$$(cat $(REVIEW_APP_FILE)).herokuapp.com" \
 		$(MAKE) smoke a11y
+	# Destroy review app if it passes tests on the master branch
+ifeq ($(CIRCLE_BRANCH),master)
+	heroku destroy -a $$(cat $(REVIEW_APP_FILE)) --confirm $$(cat $(REVIEW_APP_FILE))
+endif
 	@$(DONE)


### PR DESCRIPTION
Fixes https://github.com/Financial-Times/next/issues/321

TODO:

* [x] Test it doesn't trigger for non-`master` branches (works here: https://circleci.com/gh/Financial-Times/next-search-page/2762)
* [ ] Check `master` branch (only after PR merge, on a nightly build)