### PR TITLE
Configure the review app after it is created/found

### DIFF
--- a/src/tasks/review-app.mk
+++ b/src/tasks/review-app.mk
@@ -10,6 +10,8 @@ review-app: tidy-review-app .review-app
 
 .review-app:
 	@echo 'Creating review app for $(VAULT_NAME)'
+	
+	# Configure the pipeline
 	$(if $(REVIEW_APP_CONFIGURE_OVERRIDES),\
 	  nht configure $(VAULT_NAME) review-app --overrides "$(REVIEW_APP_CONFIGURE_OVERRIDES)", \
 	  nht configure $(VAULT_NAME) review-app --overrides NODE_ENV=branch \
@@ -20,6 +22,12 @@ review-app: tidy-review-app .review-app
 		--branch $(CIRCLE_BRANCH) \
 		--commit $(CIRCLE_SHA1) \
 		--github-token $(GITHUB_AUTH_TOKEN) > $@
+
+	# Configure the review app
+	$(if $(REVIEW_APP_CONFIGURE_OVERRIDES),\
+	  nht configure $(VAULT_NAME) $$(cat $(REVIEW_APP_FILE)) --overrides "$(REVIEW_APP_CONFIGURE_OVERRIDES)", \
+	  nht configure $(VAULT_NAME) $$(cat $(REVIEW_APP_FILE)) --overrides NODE_ENV=branch \
+	)
 
 gtg-review-app: review-app
 	nht gtg $$(cat $(REVIEW_APP_FILE))


### PR DESCRIPTION
Needed when a review app has already been created, and gets returned, as
the pipeline configuration variables aren’t sync’d. This also means that
a new review app has its variables set twice, but I think that is ok.

See https://github.com/Financial-Times/next/issues/331 🐿 v2.11.0