### PR TITLE
Removed check to enforce repo ownership with an ft.yml file

### DIFF
--- a/src/setup.mk
+++ b/src/setup.mk
@@ -14,13 +14,6 @@ $(info Note — An .env file exists. Its contents have been exported as environm
 endif
 endif
 
-# Enforce repo ownership
-ifeq ("$(wildcard ft.yml)","")
-$(error 'Projects making use of n-gage *must* define an ft.yml file containing the repo owner’s details (see any next- repo for required structure)')
-$(error 'If you are creating a project not to be maintained by the next team please feel free to copy what you need from our build tools but don’t add an ft.yml.')
-$(error 'Integrating with our tooling may result in unwanted effects e.g. nightly builds, slack alerts, emails etc')
-endif
-
 # ./node_modules/.bin on the PATH
 export PATH := $(PATH):$(ngage-dir)node_modules/.bin:./node_modules/.bin
 


### PR DESCRIPTION
Removed check to enforce repo ownership with an ft.yml file (moving to CODEOWNERS)

 🐿 v2.12.0