### PR TITLE
fix dotfile installation, fixes #162

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,10 @@ integration-test-%: $(fixture-base)/%
 # run a handful of standard next make commands in the fixture folder using the `-C DIRECTORY` option
 	$(MAKE) -C $< install build
 
+# ensure the folders have some basic things we would expect from install
+	[ -d $</node_modules ]
+	[ -f $</.editorconfig ]
+
 integration-test: $(fixture-targets)
 
 clean-fixtures:

--- a/src/tasks/install.mk
+++ b/src/tasks/install.mk
@@ -1,5 +1,5 @@
 instal%: ## install: Setup this repository.
-instal%: node_modules bower_components $(dotfiles)
+instal%: node_modules bower_components dotfiles
 	$(MAKE) $(foreach f, $(shell find functions/* -type d -maxdepth 0 2>/dev/null), $f/node_modules $f/bower_components)
 	@$(DONE)
 	@if [ -z $(CIRCLECI) ] && [ ! -e .env ]; then (echo "Note: If this is a development environment, you will likely need to import the project's environment variables by running 'make .env'."); fi
@@ -29,8 +29,10 @@ functions/%/bower_components:
 
 # Manage various dot/config files if they're in the .gitignore
 dotfiles-dir = $(ngage-dir)dotfiles
-dotfiles-source = $(wildcard $(dotfiles-dir)/.*)
+dotfiles-source = $(wildcard $(dotfiles-dir)/.[!.]*)
 dotfiles = $(patsubst $(ngage-dir)dotfiles/%, %, $(dotfiles-source))
+
+dotfiles: $(dotfiles)
 
 .%: $(dotfiles-dir)/.%
 	@if $(call IS_GIT_IGNORED); then cp $< $@ && $(DONE); fi


### PR DESCRIPTION
- i don't know exactly why this works
- bash `.*` includes the virtual files `.` and `..`
- filtering those out seems to make this work
- also making sure `$(dotfiles)` is defined before it's used
- which based on my understanding of make variables shouldn't be needed