### PR TITLE
Update eslintrc to fix deprecated option

### DIFF
--- a/dotfiles/.eslintrc.js
+++ b/dotfiles/.eslintrc.js
@@ -7,11 +7,8 @@ const config = {
 		'node': true
 	},
 	'parserOptions': {
-		'ecmaVersion': 2017,
-		'sourceType': 'module',
-		'ecmaFeatures': {
-			'experimentalObjectRestSpread': true
-		}
+		'ecmaVersion': 2018,
+		'sourceType': 'module'
 	},
 	'rules': {
 		'eqeqeq': 'error',


### PR DESCRIPTION
close #183
Since we fixed dotfile imports in n-gage more repo started picking up this configuration. One of the property was deprecated so I had to bump ecmaVersion.