### PR TITLE
Add node_modules/.metadata_never_index on install

### DIFF
--- a/src/tasks/install.mk
+++ b/src/tasks/install.mk
@@ -9,7 +9,7 @@ instal%: node_modules bower_components dotfiles
 # Regular npm install
 node_modules: package.json
 	@if [ -e package-lock.json ]; then rm package-lock.json; fi
-	@if [ -e package.json ]; then $(NPM_INSTALL) && $(DONE); fi
+	@if [ -e package.json ]; then mkdir -p node_modules && touch node_modules/.metadata_never_index && $(NPM_INSTALL) && $(DONE); fi
 
 # Regular bower install
 bower_components: bower.json


### PR DESCRIPTION
As per the following discussion on Slack: https://financialtimes.slack.com/archives/C0ECBA4GY/p1554372261034100, which followed on from this Tweet: https://twitter.com/roelvangils/status/1113074439976075264