### PR TITLE
Add errors for trailing whitespace and bad indents

### DIFF
--- a/dotfiles/.eslintrc.js
+++ b/dotfiles/.eslintrc.js
@@ -13,6 +13,7 @@ const config = {
 	'rules': {
 		'eqeqeq': 'error',
 		'guard-for-in': 'error',
+		'indent': ['error', 'tab'],
 		'new-cap': 'off',
 		'no-caller': 'error',
 		'no-console': 'error',
@@ -20,6 +21,7 @@ const config = {
 		'no-irregular-whitespace': 'error',
 		'no-loop-func': 'error',
 		'no-multi-spaces': 'error',
+		'no-trailing-spaces': 'error',
 		'no-undef': 'error',
 		'no-underscore-dangle': 'off',
 		'no-unused-vars': 'error',


### PR DESCRIPTION
Repos using n-gage throw linting errors for these, but the eslint.rc file was not configured to show them visibly as errors, meaning they were difficult to fix.

I've spoken with @quarterto about how this overlaps with the settings in the Editor Config file. The issue is that there doesn't seem to be a way to show red squiggly line errors for Editor Config, meaning it's difficult to fix those errors. They are looking into a future fix for this, but in the meantime have said this is a good step to take for the eslint.rc file.