### PR TITLE
enable setting of additional env choices for get-config

### DIFF
--- a/scripts/commands/get-config.js
+++ b/scripts/commands/get-config.js
@@ -4,6 +4,13 @@ const path = require('path');
 const os = require('os');
 const appendSessionTokens = require('../append-session-tokens');
 
+const {ADDITIONAL_VAULT_ENVIRONMENTS} = process.env;
+const envChoices = ['dev', 'prod', 'ci', 'test'];
+
+if (ADDITIONAL_VAULT_ENVIRONMENTS) {
+	envChoices.push(...ADDITIONAL_VAULT_ENVIRONMENTS.split(','))
+}
+
 exports.command = 'get-config';
 exports.describe = 'get environment variables from Vault';
 
@@ -23,9 +30,9 @@ exports.builder = yargs => (yargs
 		}
 	})())
 	.option('env', {
-		choices: ['dev', 'prod', 'ci', 'test'],
+		choices: envChoices,
 		default: 'dev'
-  })
+  	})
 	.option('filename', {
 		coerce: value => typeof value === 'string' ? value : '.env',
 		default: '.env'


### PR DESCRIPTION
# enable setting of additional env choices for get-config

## What
Enables setting of additional env choices via project `ADDITIONAL_VAULT_ENVIRONMENTS` environment variable.

## Why
In `next-myft-email` we have a need to be able to deploy to a `sandbox` environment, we also will potentially in the future desire different environment variables for a `staging` environment.

This enables this to be configurable on a project specific basis.

 🐿 v2.12.3