### PR TITLE
Update the SwitchCase indent rule

### DIFF
--- a/dotfiles/.eslintrc.js
+++ b/dotfiles/.eslintrc.js
@@ -13,7 +13,7 @@ const config = {
 	'rules': {
 		'eqeqeq': 'error',
 		'guard-for-in': 'error',
-		'indent': ['error', 'tab'],
+		'indent': ['error', 'tab', {'SwitchCase': 1}],
 		'new-cap': 'off',
 		'no-caller': 'error',
 		'no-console': 'error',


### PR DESCRIPTION
In a recent eslint update it seems they have defaulted the `SwichCase` rule to `0`. This means the switch statements were being auto corrected to look different from before.

For example -

```js
switch (thing) {
    case 1:
        ...
    case 2:
        ...
}
```

Was being formatted to be -

```js
switch (thing) {
case 1:
    ...
case 2:
    ...
}
```