### PR TITLE
Use circle repo name instead of vault

### DIFF
--- a/src/tasks/deploy.mk
+++ b/src/tasks/deploy.mk
@@ -101,7 +101,7 @@ change-api:
 				\"githubName\": \"$(CIRCLE_USERNAME)\" \
 			}, \
 			\"environment\": \"production\", \
-			\"systemCode\": \"$(VAULT_NAME)\", \
+			\"systemCode\": \"$(CIRCLE_PROJECT_REPONAME)\", \
 			\"commit\": \"$(CIRCLE_SHA1)\" \
 		}" \
 		https://api.ft.com/change-log/v1/create


### PR DESCRIPTION
`CIRCLE_PROJECT_REPONAME` should provide a name closer to the desired `systemcode` field we want.

https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables