### PR TITLE
make rm not error instead of suppressing its error

### DIFF
--- a/src/tasks/review-app.mk
+++ b/src/tasks/review-app.mk
@@ -4,7 +4,7 @@
 REVIEW_APP_FILE := .review-app
 
 tidy-review-app:
-	-rm $(REVIEW_APP_FILE)
+	rm -f $(REVIEW_APP_FILE)
 
 review-app: tidy-review-app .review-app
 


### PR DESCRIPTION
otherwise, it prints `rm: cannot remove '.review-app': No such file or directory`, which looks like an error when you're scanning CI logs but it isn't one, which is misleading when the build breaks because it's never because of that but it looks like it's an error and it's the first thing you see

closes #187 if done with financial-times/n-heroku-tools#577