### PR TITLE
Remove bower_components directory before install

### DIFF
--- a/src/setup.mk
+++ b/src/setup.mk
@@ -34,7 +34,7 @@ endif
 GLOB = git ls-files -z $1 | tr '\0' '\n' | xargs -I {} find {} ! -type l
 
 NPM_INSTALL = npm prune --production=false --no-package-lock && npm install --no-package-lock
-BOWER_INSTALL = bower prune && bower install --config.registry.search=https://origami-bower-registry.ft.com --config.registry.search=https://registry.bower.io
+BOWER_INSTALL = rm -rf bower_components && bower install --config.registry.search=https://origami-bower-registry.ft.com --config.registry.search=https://registry.bower.io
 
 JSON_GET_VALUE = grep $1 | head -n 1 | sed 's/[," ]//g' | cut -d : -f 2
 APP_NAME = $(shell cat package.json 2>/dev/null | $(call JSON_GET_VALUE,name))


### PR DESCRIPTION
A lot of developer confusion occurs when a project that was downloaded a while ago needs to be installed again, the user gets hit with a whole bunch of strange and frustrating conflicts. Bower does some silly stuff with looking at the `bower_components` directory before trying to build its tree that can be completely avoided if the `bower_components` directory isn't there.

let's do this bit for them