### PR TITLE
Split the deploy task into two sub-tasks for staging and promotion to prod.

### DIFF
--- a/src/tasks/deploy.mk
+++ b/src/tasks/deploy.mk
@@ -63,7 +63,7 @@ deploy-canary: ## deploy-canary: deploy canary app to staging
 deploy-staging: ## deploy-staging: deploy the app to staging.
 	$(call ASSERT_VARS_EXIST, HEROKU_APP_STAGING VAULT_NAME)
 	$(call ASSERT_ANY_VAR_EXISTS, HEROKU_APP_EU HEROKU_APP_US)
-	# Reset repository so that the app deploys on rebuilds even though there is no code change
+# Reset repository so that the app deploys on rebuilds even though there is no code change
 	heroku repo:reset -a $(HEROKU_APP_STAGING)
 
 	@echo "Setting environment variables for $(HEROKU_APP_STAGING)..."

--- a/src/tasks/deploy.mk
+++ b/src/tasks/deploy.mk
@@ -60,10 +60,10 @@ deploy-canary: ## deploy-canary: deploy canary app to staging
 
 	$(MAKE) change-api
 
-deplo%: ## deploy: deploy the app to heroku
+deploy-staging: ## deploy-staging: deploy the app to staging.
 	$(call ASSERT_VARS_EXIST, HEROKU_APP_STAGING VAULT_NAME)
 	$(call ASSERT_ANY_VAR_EXISTS, HEROKU_APP_EU HEROKU_APP_US)
-# Reset repository so that the app deploys on rebuilds even though there is no code change
+	# Reset repository so that the app deploys on rebuilds even though there is no code change
 	heroku repo:reset -a $(HEROKU_APP_STAGING)
 
 	@echo "Setting environment variables for $(HEROKU_APP_STAGING)..."
@@ -78,6 +78,10 @@ deplo%: ## deploy: deploy the app to heroku
 
 	@n-test smoke -H http://$(HEROKU_APP_STAGING).herokuapp.com --header "FT-Next-Backend-Key: $(FT_NEXT_BACKEND_KEY)" --browsers "chrome"
 
+deploy-promote: ## deploy-promote: promote the staging app to production.
+	$(call ASSERT_VARS_EXIST, HEROKU_APP_STAGING VAULT_NAME)
+	$(call ASSERT_ANY_VAR_EXISTS, HEROKU_APP_EU HEROKU_APP_US)
+
 	$(if $(HEROKU_APP_EU),\
 	  nht configure $(VAULT_NAME) $(HEROKU_APP_EU) --overrides REGION=EU \
 	)
@@ -90,6 +94,10 @@ deplo%: ## deploy: deploy the app to heroku
 	heroku dyno:scale web=0 -a $(HEROKU_APP_STAGING)
 
 	$(MAKE) change-api
+
+deplo%: ## deploy: deploy the app to heroku
+	$(MAKE) deploy-staging
+	$(MAKE) deploy-promote
 
 change-api:
 	@echo "Saving deployment to the Change API..."

--- a/src/tasks/deploy.mk
+++ b/src/tasks/deploy.mk
@@ -78,10 +78,6 @@ deploy-staging: ## deploy-staging: deploy the app to staging.
 
 	@n-test smoke -H http://$(HEROKU_APP_STAGING).herokuapp.com --header "FT-Next-Backend-Key: $(FT_NEXT_BACKEND_KEY)" --browsers "chrome"
 
-deploy-promote: ## deploy-promote: promote the staging app to production.
-	$(call ASSERT_VARS_EXIST, HEROKU_APP_STAGING VAULT_NAME)
-	$(call ASSERT_ANY_VAR_EXISTS, HEROKU_APP_EU HEROKU_APP_US)
-
 	$(if $(HEROKU_APP_EU),\
 	  nht configure $(VAULT_NAME) $(HEROKU_APP_EU) --overrides REGION=EU \
 	)
@@ -89,6 +85,9 @@ deploy-promote: ## deploy-promote: promote the staging app to production.
 	$(if $(HEROKU_APP_US),\
 	  nht configure $(VAULT_NAME) $(HEROKU_APP_US) --overrides REGION=US \
 	)
+
+deploy-promote: ## deploy-promote: promote the staging app to production.
+	$(call ASSERT_VARS_EXIST, HEROKU_APP_STAGING)
 
 	heroku pipelines:promote -a $(HEROKU_APP_STAGING)
 	heroku dyno:scale web=0 -a $(HEROKU_APP_STAGING)


### PR DESCRIPTION
This is following a [discussion on Slack](https://financialtimes.slack.com/archives/C08PF33EC/p1565272552028900).

We're in a situation on Conversion where we need to have E2E tests run on a predictable url and to block code from going out if tests fail. The best place to do this would be on staging, and to do that we need to break up the deploy task so that we can run our tests in between staging being set up and it being promoted to prod and then scaled down.

🐿 v2.10.0