### PR TITLE
Exclude doubleclick iframes from Pa11y tests

### DIFF
--- a/dotfiles/.pa11yci.js
+++ b/dotfiles/.pa11yci.js
@@ -52,7 +52,7 @@ const config = {
 		},
 		timeout: 50000,
 		wait: process.env.PA11Y_WAIT || 300,
-		hideElements: 'iframe[src*=google],iframe[src*=proxy]',
+		hideElements: 'iframe[src*=google],iframe[src*=proxy],iframe[src*=doubleclick],',
 		rules: ['Principle1.Guideline1_3.1_3_1_AAA']
 	},
 	urls: []

--- a/dotfiles/.pa11yci.js
+++ b/dotfiles/.pa11yci.js
@@ -52,7 +52,7 @@ const config = {
 		},
 		timeout: 50000,
 		wait: process.env.PA11Y_WAIT || 300,
-		hideElements: 'iframe[src*=google],iframe[src*=proxy],iframe[src*=doubleclick],',
+		hideElements: 'iframe[src*=google],iframe[src*=proxy],iframe[src*=doubleclick]',
 		rules: ['Principle1.Guideline1_3.1_3_1_AAA']
 	},
 	urls: []


### PR DESCRIPTION
Code added by Google Tag Manager may make some `pa11y` tests fail. This additional rule will exclude one source of errors.

More details on what led to this can be found [here](https://github.com/Financial-Times/next-subscribe/pull/746) and [here](https://financialtimes.slack.com/archives/C067V11G8/p1568712586010300).