### PR TITLE
replaces the existing nht deploy command with shared helpers 🐿 v2.12.5

### DIFF
--- a/src/tasks/deploy.mk
+++ b/src/tasks/deploy.mk
@@ -7,7 +7,7 @@ deploy-asset%: ## deploy-assets: uploads static files such as CSS and JS to S3 b
 			.circleci/shared-helpers/helper-upload-assets-to-s3 \
 		else \
 			echo "Could not find the shared-helpers directory" \
-		fi
+		fi \
 	else \
 		echo "Could not find a manifest.json" \
 	fi

--- a/src/tasks/deploy.mk
+++ b/src/tasks/deploy.mk
@@ -4,7 +4,7 @@ deploy-asset%: ## deploy-assets: uploads static files such as CSS and JS to S3 b
 		if [ -e .circleci/shared-helpers ]; then \
 			.circleci/shared-helpers/helper-install-awscli \
 			.circleci/shared-helpers/helper-configure-awscli $(aws_access_hashed_assets) $(aws_secret_hashed_assets) \
-			.circleci/shared-helpers/helper-upload-assets-to-s3 \
+			.circleci/shared-helpers/helper-upload-assets-to-s3 public hashed-assets/page-kit \
 		else \
 			echo "Could not find the shared-helpers directory" \
 		fi \

--- a/src/tasks/deploy.mk
+++ b/src/tasks/deploy.mk
@@ -2,7 +2,7 @@
 deploy-asset%: ## deploy-assets: uploads static files such as CSS and JS to S3 based on the contents of a manifest file
 	@if [ -e public/manifest.json ]; then \
 		if [ -e .circleci/shared-helpers ]; then \
-			.circleci/shared-helpers/helper-install-awscli; \
+			.circleci/shared-helpers/helper-install-awscli \
 			&& .circleci/shared-helpers/helper-configure-awscli $(aws_access_hashed_assets) $(aws_secret_hashed_assets); \
 			&& .circleci/shared-helpers/helper-upload-assets-to-s3 public hashed-assets/page-kit; \
 		else \

--- a/src/tasks/deploy.mk
+++ b/src/tasks/deploy.mk
@@ -2,14 +2,14 @@
 deploy-asset%: ## deploy-assets: uploads static files such as CSS and JS to S3 based on the contents of a manifest file
 	@if [ -e public/manifest.json ]; then \
 		if [ -e .circleci/shared-helpers ]; then \
-			.circleci/shared-helpers/helper-install-awscli \
-			.circleci/shared-helpers/helper-configure-awscli $(aws_access_hashed_assets) $(aws_secret_hashed_assets) \
-			.circleci/shared-helpers/helper-upload-assets-to-s3 public hashed-assets/page-kit \
+			.circleci/shared-helpers/helper-install-awscli; \
+			&& .circleci/shared-helpers/helper-configure-awscli $(aws_access_hashed_assets) $(aws_secret_hashed_assets); \
+			&& .circleci/shared-helpers/helper-upload-assets-to-s3 public hashed-assets/page-kit; \
 		else \
-			echo "Could not find the shared-helpers directory" \
+			echo "Could not find the shared-helpers directory"; \
 		fi \
 	else \
-		echo "Could not find a manifest.json" \
+		echo "Could not find a manifest.json"; \
 	fi
 
 	@if [ -e public/asset-hashes.json ]; then \

--- a/src/tasks/deploy.mk
+++ b/src/tasks/deploy.mk
@@ -3,7 +3,7 @@ deploy-asset%: ## deploy-assets: uploads static files such as CSS and JS to S3 b
 	@if [ -e public/manifest.json ]; then \
 		if [ -e .circleci/shared-helpers ]; then \
 			.circleci/shared-helpers/helper-install-awscli \
-			&& .circleci/shared-helpers/helper-configure-awscli $(aws_access_hashed_assets) $(aws_secret_hashed_assets); \
+			&& .circleci/shared-helpers/helper-configure-awscli $(aws_access_hashed_assets) $(aws_secret_hashed_assets) \
 			&& .circleci/shared-helpers/helper-upload-assets-to-s3 public hashed-assets/page-kit; \
 		else \
 			echo "Could not find the shared-helpers directory"; \

--- a/src/tasks/deploy.mk
+++ b/src/tasks/deploy.mk
@@ -1,14 +1,18 @@
 #Must be above deplo%
 deploy-asset%: ## deploy-assets: uploads static files such as CSS and JS to S3 based on the contents of a manifest file
-	@if [ -e public/manifest.json ] && [ -e .circleci/shared-helpers ]; then\
-		.circleci/shared-helpers/helper-install-awscli \
-		.circleci/shared-helpers/helper-upload-assets-to-s3 \
-	@else
-		@echo "Could not find the shared-helpers directory"
+	@if [ -e public/manifest.json ]; then \
+		if [ -e .circleci/shared-helpers ]; then \
+			.circleci/shared-helpers/helper-install-awscli \
+			.circleci/shared-helpers/helper-upload-assets-to-s3 \
+		else \
+			echo "Could not find the shared-helpers directory" \
+		fi
+	else \
+		echo "Could not find a manifest.json" \
 	fi
 
-	@if [ -e public/asset-hashes.json ]; then\
-		nht deploy-hashed-assets --monitor-assets;\
+	@if [ -e public/asset-hashes.json ]; then \
+		nht deploy-hashed-assets --monitor-assets; \
 	fi
 
 #Must be above deplo%

--- a/src/tasks/deploy.mk
+++ b/src/tasks/deploy.mk
@@ -1,7 +1,10 @@
 #Must be above deplo%
 deploy-asset%: ## deploy-assets: uploads static files such as CSS and JS to S3 based on the contents of a manifest file
-	@if [ -e public/manifest.json ]; then\
-		nht deploy-hashed-assets --monitor-assets --manifest-file manifest.json --assets-are-hashed --destination-directory page-kit;\
+	@if [ -e public/manifest.json ] && [ -e .circleci/shared-helpers ]; then\
+		.circleci/shared-helpers/helper-install-awscli \
+		.circleci/shared-helpers/helper-upload-assets-to-s3 \
+	@else
+		@echo "Could not find the shared-helpers directory"
 	fi
 
 	@if [ -e public/asset-hashes.json ]; then\

--- a/src/tasks/deploy.mk
+++ b/src/tasks/deploy.mk
@@ -3,6 +3,7 @@ deploy-asset%: ## deploy-assets: uploads static files such as CSS and JS to S3 b
 	@if [ -e public/manifest.json ]; then \
 		if [ -e .circleci/shared-helpers ]; then \
 			.circleci/shared-helpers/helper-install-awscli \
+			.circleci/shared-helpers/helper-configure-awscli $(aws_access_hashed_assets) $(aws_secret_hashed_assets) \
 			.circleci/shared-helpers/helper-upload-assets-to-s3 \
 		else \
 			echo "Could not find the shared-helpers directory" \


### PR DESCRIPTION
Refactors the deploy assets command in n-gage to remove the dependency on n-heroku-tools for apps which are using Page Kit

[PR to add the aws-cli helpers](https://github.com/Financial-Times/next-ci-shared-helpers/pull/22)
[PR to add the upload assets to S3 helper](https://github.com/Financial-Times/next-ci-shared-helpers/pull/23)

Related issue on Page Kit: https://github.com/Financial-Times/next-ci-shared-helpers/issues/21