### PR TITLE
Revert "replaces the existing nht deploy command with shared helpers 🐿 v2.12.5"

### DIFF
--- a/src/tasks/deploy.mk
+++ b/src/tasks/deploy.mk
@@ -1,19 +1,11 @@
 #Must be above deplo%
 deploy-asset%: ## deploy-assets: uploads static files such as CSS and JS to S3 based on the contents of a manifest file
-	@if [ -e public/manifest.json ]; then \
-		if [ -e .circleci/shared-helpers ]; then \
-			.circleci/shared-helpers/helper-install-awscli \
-			&& .circleci/shared-helpers/helper-configure-awscli $(aws_access_hashed_assets) $(aws_secret_hashed_assets) \
-			&& .circleci/shared-helpers/helper-upload-assets-to-s3 public hashed-assets/page-kit; \
-		else \
-			echo "Could not find the shared-helpers directory"; \
-		fi \
-	else \
-		echo "Could not find a manifest.json"; \
+	@if [ -e public/manifest.json ]; then\
+		nht deploy-hashed-assets --monitor-assets --manifest-file manifest.json --assets-are-hashed --destination-directory page-kit;\
 	fi
 
-	@if [ -e public/asset-hashes.json ]; then \
-		nht deploy-hashed-assets --monitor-assets; \
+	@if [ -e public/asset-hashes.json ]; then\
+		nht deploy-hashed-assets --monitor-assets;\
 	fi
 
 #Must be above deplo%


### PR DESCRIPTION
Reverts Financial-Times/n-gage#213

This change introduced errors related to loading hashed assets which are discussed in this [ops-cops trello ticket](https://trello.com/c/5oMTap8b/1383-403s-on-next-search-page-related-to-hashed-assets)

This implementation assumed that the asset-upload step was triggered by CI, but it's not - the `make upload-assets` script is triggered as part of the `heroku-postbuild` script. 

We will need to rethink our implementation. 