### PR TITLE
Include Cypress files in no-only-tests ES Lint check

### DIFF
--- a/dotfiles/.eslintrc.js
+++ b/dotfiles/.eslintrc.js
@@ -46,7 +46,7 @@ const config = {
 	'extends': [],
 	'overrides': [
 		{
-			'files': [ 'test/**/*.js', 'tests/**/*.js' ],
+			'files': [ 'test/**/*.js', 'tests/**/*.js', 'cypress/**/*.js' ],
 			'rules': {
 				'no-only-tests/no-only-tests': 'error'
 			}


### PR DESCRIPTION
Ensures any usage of `.only` in test files located in the root level `/cypress` directory also has ES Lint check for `no-only-tests` applied.

This seems a lot simpler than overriding the Cypress default (i.e. keeping `/cypress` directory at root level, done in `next-retention`, `next-subscribe`, `next-profile`, and maybe more) by nesting the `/cypress` directory inside the root level `/test` directory.

This change will ensure that instances such as [this](https://github.com/Financial-Times/next-retention/pull/363/files) are caught in future.