### PR TITLE
Use new config format for Husky commit hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,6 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "precommit": "secret-squirrel",
-    "prepush": "make verify -j3",
-    "commitmsg": "secret-squirrel-commitmsg",
     "prepare": "npx snyk protect || npx snyk protect -d || true"
   },
   "bin": {
@@ -45,5 +42,12 @@
     "sinon": "^4.1.3",
     "sinon-chai": "^2.14.0",
     "snyk": "^1.167.2"
+  },
+  "husky": {
+    "hooks": {
+      "commit-msg": "secret-squirrel-commitmsg",
+      "pre-commit": "secret-squirrel",
+      "pre-push": "make verify -j3"
+    }
   }
 }

--- a/scripts/githooks.js
+++ b/scripts/githooks.js
@@ -73,29 +73,26 @@ const preGitHookExists = () => {
 };
 
 const run = () => {
-	return new Promise(resolve => {
-		var response = '';
+	var response = '';
 
-		// Only run locally (not in CI)
-		if (process.env.CIRCLECI) {
-			return resolve(response);
-		}
+	// Only run locally (not in CI)
+	if (process.env.CIRCLECI) {
+		return response;
+	}
 
-		if (!secretSquirrelPreCommitScriptExists() || !secretSquirrelCommitmsgScriptExists()) {
-			writePackageJsonFile(addScripts);
-			response += 'It added some githook scripts. ';
-		};
-		if (preGitHookExists()) {
-			writePackageJsonFile(removePreGitHooks);
-			response += 'It deleted some config > pre-git hooks. IMPORTANT: Delete the old local hooks with: "rm -rf .git/hooks/*" ';
-		};
-		if (response !== '') {
-			response = `✗ Note: n-gage just edited package.json. ${response} Please review and commit`;
-		}
-		return resolve(response);
-	});
+	if (!secretSquirrelPreCommitScriptExists() || !secretSquirrelCommitmsgScriptExists()) {
+		writePackageJsonFile(addScripts);
+		response += 'It added some githook scripts. ';
+	};
+	if (preGitHookExists()) {
+		writePackageJsonFile(removePreGitHooks);
+		response += 'It deleted some config > pre-git hooks. IMPORTANT: Delete the old local hooks with: "rm -rf .git/hooks/*" ';
+	};
+	if (response !== '') {
+		response = `✗ Note: n-gage just edited package.json. ${response} Please review and commit`;
+	}
+	return response;
 }
 
-run().then(response => {
-	console.log(response)
-});
+const response = run();
+console.log(response);

--- a/scripts/githooks.js
+++ b/scripts/githooks.js
@@ -57,6 +57,11 @@ const find = test => {
 	};
 };
 
+const huskyConfigNeedsUpgrade = () => {
+	const { scripts } = getPackageJson();
+	return Boolean(scripts && (scripts.precommit || scripts.commitmsg || scripts.commitmsg));
+};
+
 const secretSquirrelPreCommitScriptExists = () => {
 	const json = getPackageJson();
 	return find(() => json.scripts.precommit.indexOf('secret-squirrel') !== -1);
@@ -80,6 +85,10 @@ const run = () => {
 		return response;
 	}
 
+	if (huskyConfigNeedsUpgrade()) {
+		require(`${process.cwd()}/node_modules/.bin/husky-upgrade`);
+		response += 'It upgraded the Husky config format - see https://github.com/Financial-Times/n-gage/issues/220. ';
+	}
 	if (!secretSquirrelPreCommitScriptExists() || !secretSquirrelCommitmsgScriptExists()) {
 		writePackageJsonFile(addScripts);
 		response += 'It added some githook scripts. ';

--- a/scripts/githooks.js
+++ b/scripts/githooks.js
@@ -62,7 +62,7 @@ const find = test => {
 
 const huskyConfigNeedsUpgrade = () => {
 	const { scripts } = getPackageJson();
-	return Boolean(scripts && (scripts.precommit || scripts.commitmsg || scripts.commitmsg));
+	return Boolean(scripts && (scripts.precommit || scripts.commitmsg || scripts.prepush));
 };
 
 const secretSquirrelPreCommitScriptExists = () => {

--- a/scripts/githooks.js
+++ b/scripts/githooks.js
@@ -18,15 +18,18 @@ const addScript = (json, config) => {
 	const name = config.name;
 	const value = config.value;
 	const newJson = JSON.parse(JSON.stringify(json));
-	if (!newJson.scripts) {
-		newJson.scripts = {};
+	if (!newJson.husky) {
+		newJson.husky = {};
+	}
+	if (!newJson.husky.hooks) {
+		newJson.husky.hooks = {};
 	}
 
-	if (!newJson.scripts[name]) {
-		newJson.scripts[name] = value;
+	if (!newJson.husky.hooks[name]) {
+		newJson.husky.hooks[name] = value;
 	}
-	else if (newJson.scripts[name].indexOf(value) === -1) {
-		newJson.scripts[name] = `${newJson.scripts[name]} && ${value}`;
+	else if (newJson.husky.hooks[name].indexOf(value) === -1) {
+		newJson.husky.hooks[name] = `${newJson.husky.hooks[name]} && ${value}`;
 	}
 	return newJson;
 }
@@ -34,9 +37,9 @@ const addScript = (json, config) => {
 const addScripts = () => {
 	const json = getPackageJson();
 	const newJson = [
-		{ name: 'precommit', value: 'secret-squirrel' },
-		{ name: 'commitmsg', value: 'secret-squirrel-commitmsg' },
-		{ name: 'prepush', value: 'make verify -j3' }
+		{ name: 'pre-commit', value: 'secret-squirrel' },
+		{ name: 'commit-msg', value: 'secret-squirrel-commitmsg' },
+		{ name: 'pre-push', value: 'make verify -j3' }
 	].reduce((returnObject, row) => addScript(returnObject, row), json);
 	return newJson;
 }
@@ -64,12 +67,20 @@ const huskyConfigNeedsUpgrade = () => {
 
 const secretSquirrelPreCommitScriptExists = () => {
 	const json = getPackageJson();
-	return find(() => json.scripts.precommit.indexOf('secret-squirrel') !== -1);
+	try {
+		return find(() => json.husky.hooks['pre-commit'].indexOf('secret-squirrel') !== -1);
+	} catch (e) {
+		return false;
+	}
 };
 
 const secretSquirrelCommitmsgScriptExists = () => {
 	const json = getPackageJson();
-	return find(() => json.scripts.commitmsg.indexOf('secret-squirrel-commitmsg') !== -1);
+	try {
+		return find(() => json.husky.hooks['commit-msg'].indexOf('secret-squirrel-commitmsg') !== -1);
+	} catch (e) {
+		return false;
+	}
 };
 
 const preGitHookExists = () => {

--- a/scripts/githooks.js
+++ b/scripts/githooks.js
@@ -62,25 +62,17 @@ const find = test => {
 
 const huskyConfigNeedsUpgrade = () => {
 	const { scripts } = getPackageJson();
-	return Boolean(scripts && (scripts.precommit || scripts.commitmsg || scripts.prepush));
+	return find(() => scripts.precommit || scripts.commitmsg || scripts.prepush);
 };
 
 const secretSquirrelPreCommitScriptExists = () => {
 	const json = getPackageJson();
-	try {
-		return find(() => json.husky.hooks['pre-commit'].indexOf('secret-squirrel') !== -1);
-	} catch (e) {
-		return false;
-	}
+	return find(() => json.husky.hooks['pre-commit'].indexOf('secret-squirrel') !== -1);
 };
 
 const secretSquirrelCommitmsgScriptExists = () => {
 	const json = getPackageJson();
-	try {
-		return find(() => json.husky.hooks['commit-msg'].indexOf('secret-squirrel-commitmsg') !== -1);
-	} catch (e) {
-		return false;
-	}
+	return find(() => json.husky.hooks['commit-msg'].indexOf('secret-squirrel-commitmsg') !== -1);
 };
 
 const preGitHookExists = () => {


### PR DESCRIPTION
Todo (see also below):

- [ ] Migrate components using `n-gage` (should be automatic with these changes)
- [ ] Tests (check they still work, possibly add new ones)

Integration tests are failing due to [`src/setup.mk` lines 23-27](https://github.com/Financial-Times/n-gage/blob/c66177e63e496e7b425b6b5715460d4ef3ddd858/src/setup.mk#L23_L27) which checks that `n-gage` didn't modify existing hooks - with this PR, the old format is migrated automatically, so components using `n-gage` will need to be updated.

This would have to be done either after this PR is merged, or using `--no-verify` for those repositories which need changing, as otherwise `n-gage` will try to revert to the old format.

Also they don't seem to be working properly on CircleCI since they are passing 🤔 

Fixes #220