### PR TITLE
Update http -> https for canary + staging apps

### DIFF
--- a/src/tasks/deploy.mk
+++ b/src/tasks/deploy.mk
@@ -39,7 +39,7 @@ deploy-production: ## deploy-production: deploy staging to production eu and us 
 #Must be above deplo%
 deploy-canary: ## deploy-canary: deploy canary app to staging
 	@echo "Checking for existing canary app..."
-	! curl http://$(HEROKU_APP_CANARY).herokuapp.com/__gtg -Is --fail
+	! curl https://$(HEROKU_APP_CANARY).herokuapp.com/__gtg -Is --fail
 # Exits early on successful curl to the canary app
 	@echo "Continuing with build as no existing canary app detected"
 	$(call ASSERT_VARS_EXIST, HEROKU_APP_STAGING VAULT_NAME HEROKU_APP_CANARY)
@@ -56,7 +56,7 @@ deploy-canary: ## deploy-canary: deploy canary app to staging
 
 	nht gtg $(HEROKU_APP_STAGING)
 
-	@n-test smoke -H http://$(HEROKU_APP_STAGING).herokuapp.com --header "FT-Next-Backend-Key: $(FT_NEXT_BACKEND_KEY)" --browsers "chrome"
+	@n-test smoke -H https://$(HEROKU_APP_STAGING).herokuapp.com --header "FT-Next-Backend-Key: $(FT_NEXT_BACKEND_KEY)" --browsers "chrome"
 
 	nht configure $(VAULT_NAME) $(HEROKU_APP_CANARY) --overrides "FT_APP_VARIANT=canary" \
 
@@ -87,7 +87,7 @@ deploy-staging: ## deploy-staging: deploy the app to staging.
 
 	nht gtg $(HEROKU_APP_STAGING)
 
-	@n-test smoke -H http://$(HEROKU_APP_STAGING).herokuapp.com --header "FT-Next-Backend-Key: $(FT_NEXT_BACKEND_KEY)" --browsers "chrome"
+	@n-test smoke -H https://$(HEROKU_APP_STAGING).herokuapp.com --header "FT-Next-Backend-Key: $(FT_NEXT_BACKEND_KEY)" --browsers "chrome"
 
 	$(if $(HEROKU_APP_EU),\
 	  nht configure $(VAULT_NAME) $(HEROKU_APP_EU) --overrides REGION=EU \


### PR DESCRIPTION
**24 Jan 2019:**
This line makes smoke tests against the _staging_ app use **http**:
https://github.com/Financial-Times/n-gage/blob/master/src/tasks/deploy.mk#L90

It was switched from **https** to **http** in commit: `http for staging as well` https://github.com/Financial-Times/n-gage/pull/146/commits/3217f54ea5d056301ab4562f0f2804fcff3e21b9 (part of this PR: https://github.com/Financial-Times/n-gage/pull/146).

**04 Jul 2019:**
This line makes smoke tests against the _review_ apps use **https**:
https://github.com/Financial-Times/n-gage/blob/master/src/tasks/review-app.mk#L37

It was switched from **http** to **https** in PR: `use https for TEST_URL` https://github.com/Financial-Times/n-gage/pull/200.

---

On [`next-houston`](https://github.com/Financial-Times/next-houston), upon implementing Okta authorisation (causing **https** requests to return 401 and **http** requests to return 302), its CI builds are currently affected by this disparity.

### Review app
✅ **BRANCH** (`provision` step): https://circleci.com/gh/Financial-Times/next-houston/3076
`provision` > `Create and test Heroku review app` > `make test-review-app`
Polls for gtg: ✅ http://ft-next-hous-replace-s3-jympqk.herokuapp.com/__gtg
Smoke tests `/` expecting 401: ✅ https://ft-next-hous-replace-s3-jympqk.herokuapp.com/
^^^ N.B. **http** for polling, but **https** for smoke.

Re-created app in Heroku: https://ft-next-hous-fix-smoke-ix2wjw9.herokuapp.com/

cURL:
GET http://ft-next-hous-fix-smoke-ix2wjw9.herokuapp.com/__gtg = **200 OK**
GET https://ft-next-hous-fix-smoke-ix2wjw9.herokuapp.com/__gtg = **200 OK**
GET http://ft-next-hous-fix-smoke-ix2wjw9.herokuapp.com/ = **401 Unauthorized**
GET https://ft-next-hous-fix-smoke-ix2wjw9.herokuapp.com/ = **401 Unauthorized**

### Staging app
❌ **MASTER** (`deploy` step): https://circleci.com/gh/Financial-Times/next-houston/3086
`deploy` > `Deploy to production` > `make deploy`
Polls for gtg: 😐❌ (i.e. does not explicitly say if it has passed or failed, although seems to have failed owing to `"maximum redirect"`) http://ft-next-houston-staging.herokuapp.com/__gtg
Smoke tests `/` expecting 401: ❌ http://ft-next-houston-staging.herokuapp.com/ (`"Expected: 401, got: 302"`)
^^^ Note **http** for both polling and smoke.

cURL:
GET http://ft-next-houston-staging.herokuapp.com/__gtg = **302 Found**
GET https://ft-next-houston-staging.herokuapp.com/__gtg = **200 OK**
GET http://ft-next-houston-staging.herokuapp.com/ = **302 Found**
GET https://ft-next-houston-staging.herokuapp.com/ = **401 Unauthorized**

---

I feel we should be consistent in how we run smoke tests against review, canary, and staging apps.

Given review apps support **https** (and is what they now use for smoke tests), I think we should revert the staging apps (along with the canary apps) to do the same, which this PR does.