### PR TITLE
Add flag for disabling configuration of git hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,16 @@ node_modules/@financial-times/n-gage/index.mk:
 
 See [here](#bootstrapping) for more explanation of the bootstrapping logic.  You will want to add `unit-test`, `test`, `provision`, `smoke` and `deploy` tasks to the `Makefile`. See other, similar Next projects for ideas.
 
+## Git hooks
+
+By default `n-gage` will automatically configure [some git hooks](scripts/githooks.js)
+to be run by [Husky](https://www.npmjs.com/package/husky). If you want to disable
+this behaviour, add the following line to the very top of your `Makefile`:
+
+```makefile
+DISABLE_GITHOOKS=true
+```
+
 ## Make tasks
 
 See in [index.mk](index.mk) for all the different tasks you can use in your `Makefile`.

--- a/src/setup.mk
+++ b/src/setup.mk
@@ -21,9 +21,11 @@ export PATH := $(PATH):$(ngage-dir)node_modules/.bin:./node_modules/.bin
 SHELL := /bin/bash
 
 # verify that githooks are configured correctly
+ifeq ($(DISABLE_GITHOOKS),)
 GITHOOKS := $(shell node $(ngage-dir)scripts/githooks.js)
 ifneq ("$(GITHOOKS)","")
 $(error $(GITHOOKS))
+endif
 endif
 
 #


### PR DESCRIPTION
In most cases it's sensible for `n-gage` to automatically configure the git hooks that are run by Husky, however sometimes this behaviour isn't desirable e.g. if you have `n-gage` configured in a monorepo, where the git hooks are needed at the root of the project, but not in the directory for a package where `n-gage` is used to take care of things like installing dependencies and generating an `.env` file.

Example of using the new `DISABLE_GITHOOKS` flag: https://github.com/Financial-Times/globetrotter/pull/374/files#diff-d51759f948926f1349d4ea853fd7e010R1