### PR TITLE
Quote PATH variable to prevent space splitting

### DIFF
--- a/src/setup.mk
+++ b/src/setup.mk
@@ -18,7 +18,7 @@ endif
 export PATH := $(PATH):$(ngage-dir)node_modules/.bin:./node_modules/.bin
 
 # Use bash not sh + forward path
-SHELL := env PATH=$(PATH) /bin/bash
+SHELL := env "PATH=$(PATH)" /bin/bash
 
 # verify that githooks are configured correctly
 ifeq ($(DISABLE_GITHOOKS),)


### PR DESCRIPTION
Previously this was causing issues for people with spaces in their `PATH` directories

See also #224