### PR TITLE
wait for approval before starting renovate PR builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,9 +44,15 @@ references:
     branches:
       ignore: master
 
-  filters_ignore_tags: &filters_ignore_tags
+  filters_only_renovate: &filters_only_renovate
+    branches:
+      only: /^renovate-.*/
+
+  filters_ignore_tags_and_renovate: &filters_ignore_tags_and_renovate
     tags:
       ignore: /.*/
+    branches:
+      ignore: /^renovate-.*/
 
   filters_version_tag: &filters_version_tag
     tags:
@@ -125,7 +131,20 @@ workflows:
     jobs:
       - build:
           filters:
-            <<: *filters_ignore_tags
+            <<: *filters_ignore_tags_and_renovate
+      - test:
+          requires:
+            - build
+
+  renovate-build-test:
+    jobs:
+      - waiting-for-approval:
+          type: approval
+          filters:
+            <<: *filters_ignore_tags_and_renovate
+      - build:
+          requires:
+            - waiting-for-approval
       - test:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,7 +141,7 @@ workflows:
       - waiting-for-approval:
           type: approval
           filters:
-            <<: *filters_ignore_tags_and_renovate
+            <<: *filters_only_renovate
       - build:
           requires:
             - waiting-for-approval


### PR DESCRIPTION
renovate PRs for common dependencies often fill up our circleci queue. a paused job waiting for approval doesn't count towards concurrent jobs, and it's straightforward to start this build if we need to test the PR on CI.

because this branch name uses the same format as renovate, it should match the rule so we can test this.