### PR TITLE
Remove deploy hashed assets deploy step

### DIFF
--- a/secret-squirrel.js
+++ b/secret-squirrel.js
@@ -2,6 +2,7 @@ module.exports = {
 	files: {
 		allow: [
 			'dotfiles/.stylelintrc',
+			'dotfiles/.editorconfig',
 			'.*.mk'
 		],
 		allowOverrides: []

--- a/src/tasks/deploy.mk
+++ b/src/tasks/deploy.mk
@@ -15,10 +15,6 @@ deploy-asset%: ## deploy-assets: uploads static files such as CSS and JS to S3
 			--destination="hashed-assets/page-kit"; \
 	fi
 
-	@if [ -e public/asset-hashes.json ]; then \
-		nht deploy-hashed-assets --monitor-assets; \
-	fi
-
 #Must be above deplo%
 deploy-production: ## deploy-production: deploy staging to production eu and us apps. Also scale down canary app
 	$(call ASSERT_VARS_EXIST, HEROKU_APP_STAGING VAULT_NAME HEROKU_APP_CANARY)


### PR DESCRIPTION
deploy-hashed-assets is deprecated so we want to remove it from everything, this depends on applications removing their use of the asset-hashes.json file which should be done before upgrading to this version.

This is a breaking change.

Migration documentation for release notes:

Remove deploy-hashed-assets step in deploy which looks for a asset-hashes.json file in the project.

Check if you have a `asset-hashes.json` file, if you do not, there is nothing to do.

If you do have a `asset-hashes.json` file, migrate to using `public/manifest.json` which is generated by Page Kit by default.