### PR TITLE
Fix warning from eslint-plugin-react about version

### DIFF
--- a/dotfiles/.eslintrc.js
+++ b/dotfiles/.eslintrc.js
@@ -76,6 +76,12 @@ if ((packageJsonContainsPackage('react') || packageJsonContainsPackage('preact')
 		'react/no-danger': 'off',
 		'react/no-render-return-value': 'off'
 	});
+	
+	Object.assign(config.settings, {
+		react: {
+			version: 'detect'
+		}
+	});
 }
 
 if (packageJsonContainsPackage('jest')) {


### PR DESCRIPTION
This fixes the warning which is currently emitted when ESLint is run on projects which are using React.

> Warning: React version not specified in eslint-plugin-react settings. See https://github.com/yannickcr/eslint-plugin-react#configuration .