### PR TITLE
Package lock

### DIFF
--- a/secret-squirrel.js
+++ b/secret-squirrel.js
@@ -3,6 +3,7 @@ module.exports = {
 		allow: [
 			'dotfiles/.stylelintrc',
 			'dotfiles/.editorconfig',
+			'.nvmrc',
 			'.*.mk'
 		],
 		allowOverrides: []

--- a/src/setup.mk
+++ b/src/setup.mk
@@ -35,9 +35,6 @@ endif
 # misc/legacy
 GLOB = git ls-files -z $1 | tr '\0' '\n' | xargs -I {} find {} ! -type l
 
-NPM_INSTALL = npm prune --production=false --no-package-lock && npm install --no-package-lock
-BOWER_INSTALL = rm -rf bower_components && bower install --config.registry.search=https://origami-bower-registry.ft.com --config.registry.search=https://registry.bower.io
-
 JSON_GET_VALUE = grep $1 | head -n 1 | sed 's/[," ]//g' | cut -d : -f 2
 APP_NAME = $(shell cat package.json 2>/dev/null | $(call JSON_GET_VALUE,name))
 

--- a/src/setup.mk
+++ b/src/setup.mk
@@ -38,7 +38,6 @@ GLOB = git ls-files -z $1 | tr '\0' '\n' | xargs -I {} find {} ! -type l
 JSON_GET_VALUE = grep $1 | head -n 1 | sed 's/[," ]//g' | cut -d : -f 2
 APP_NAME = $(shell cat package.json 2>/dev/null | $(call JSON_GET_VALUE,name))
 
-IS_GIT_IGNORED = grep -q $(if $1, $1, $@) .gitignore
 REPLACE_IN_GITIGNORE = sed -i -e 's/$1/$2/g' .gitignore && rm -f .gitignore-e ||:
 
 # functions for eye-catching terminal output

--- a/src/setup.mk
+++ b/src/setup.mk
@@ -38,8 +38,6 @@ GLOB = git ls-files -z $1 | tr '\0' '\n' | xargs -I {} find {} ! -type l
 JSON_GET_VALUE = grep $1 | head -n 1 | sed 's/[," ]//g' | cut -d : -f 2
 APP_NAME = $(shell cat package.json 2>/dev/null | $(call JSON_GET_VALUE,name))
 
-REPLACE_IN_GITIGNORE = sed -i -e 's/$1/$2/g' .gitignore && rm -f .gitignore-e ||:
-
 # functions for eye-catching terminal output
 COLOR = $(shell /usr/bin/env PATH=$(PATH) FORCE_COLOR=1 chalk --no-stdin -t "$1 ")
 CAPITALISE = $(shell STR="$1"; echo "$$(tr '[:lower:]' '[:upper:]' <<<"$${STR:0:1}")$${STR:1}")

--- a/src/tasks/install.mk
+++ b/src/tasks/install.mk
@@ -9,9 +9,9 @@ IS_GIT_IGNORED = grep -q $(if $1, $1, $@) .gitignore
 
 define NPM_INSTALL
 if $(call IS_GIT_IGNORED,package-lock.json); then \
-	npm prune --no-production --no-package-lock && npm install --no-package-lock \
+	npm prune --no-production --no-package-lock && npm install --no-package-lock ;\
 else \
-	npm install \
+	npm install ;\
 fi
 endef
 

--- a/src/tasks/install.mk
+++ b/src/tasks/install.mk
@@ -12,12 +12,7 @@ BOWER_INSTALL = rm -rf bower_components && bower install --config.registry.searc
 # Regular npm install
 node_modules: package.json
 	@if [ -e package-lock.json ]; then rm package-lock.json; fi
-	@if [ -e package.json ]; then \
-		mkdir -p node_modules && \
-		touch node_modules/.metadata_never_index && \
-		$(NPM_INSTALL) && \
-		$(DONE); \
-	fi
+	@if [ -e package.json ]; then $(NPM_INSTALL) && $(DONE); fi
 
 # Regular bower install
 bower_components: bower.json

--- a/src/tasks/install.mk
+++ b/src/tasks/install.mk
@@ -5,6 +5,9 @@ instal%: node_modules bower_components dotfiles
 	@if [ -z $(CIRCLECI) ] && [ ! -e .env ]; then (echo "Note: If this is a development environment, you will likely need to import the project's environment variables by running 'make .env'."); fi
 
 # INSTALL SUB-TASKS
+NPM_INSTALL = npm prune --production=false --no-package-lock && npm install --no-package-lock
+
+BOWER_INSTALL = rm -rf bower_components && bower install --config.registry.search=https://origami-bower-registry.ft.com --config.registry.search=https://registry.bower.io
 
 # Regular npm install
 node_modules: package.json

--- a/src/tasks/install.mk
+++ b/src/tasks/install.mk
@@ -5,8 +5,8 @@ instal%: node_modules bower_components dotfiles
 	@if [ -z $(CIRCLECI) ] && [ ! -e .env ]; then (echo "Note: If this is a development environment, you will likely need to import the project's environment variables by running 'make .env'."); fi
 
 # INSTALL SUB-TASKS
+IS_GIT_IGNORED = grep -q $(if $1, $1, $@) .gitignore
 NPM_INSTALL = npm prune --no-production --no-package-lock && npm install --no-package-lock
-
 BOWER_INSTALL = rm -rf bower_components && bower install --config.registry.search=https://origami-bower-registry.ft.com --config.registry.search=https://registry.bower.io
 
 # Regular npm install

--- a/src/tasks/install.mk
+++ b/src/tasks/install.mk
@@ -6,12 +6,20 @@ instal%: node_modules bower_components dotfiles
 
 # INSTALL SUB-TASKS
 IS_GIT_IGNORED = grep -q $(if $1, $1, $@) .gitignore
-NPM_INSTALL = npm prune --no-production --no-package-lock && npm install --no-package-lock
+
+define NPM_INSTALL
+if $(call IS_GIT_IGNORED,package-lock.json); then \
+	npm prune --no-production --no-package-lock && npm install --no-package-lock \
+else \
+	npm install \
+fi
+endef
+
 BOWER_INSTALL = rm -rf bower_components && bower install --config.registry.search=https://origami-bower-registry.ft.com --config.registry.search=https://registry.bower.io
 
 # Regular npm install
 node_modules: package.json
-	@if [ -e package-lock.json ]; then rm package-lock.json; fi
+	@if [ -e package-lock.json ] && $(call IS_GIT_IGNORED,package-lock.json); then rm package-lock.json; fi
 	@if [ -e package.json ]; then $(NPM_INSTALL) && $(DONE); fi
 
 # Regular bower install

--- a/src/tasks/install.mk
+++ b/src/tasks/install.mk
@@ -5,7 +5,7 @@ instal%: node_modules bower_components dotfiles
 	@if [ -z $(CIRCLECI) ] && [ ! -e .env ]; then (echo "Note: If this is a development environment, you will likely need to import the project's environment variables by running 'make .env'."); fi
 
 # INSTALL SUB-TASKS
-NPM_INSTALL = npm prune --production=false --no-package-lock && npm install --no-package-lock
+NPM_INSTALL = npm prune --no-production --no-package-lock && npm install --no-package-lock
 
 BOWER_INSTALL = rm -rf bower_components && bower install --config.registry.search=https://origami-bower-registry.ft.com --config.registry.search=https://registry.bower.io
 

--- a/src/tasks/install.mk
+++ b/src/tasks/install.mk
@@ -7,9 +7,12 @@ instal%: node_modules bower_components dotfiles
 # INSTALL SUB-TASKS
 IS_GIT_IGNORED = grep -q $(if $1, $1, $@) .gitignore
 
+# if package-lock.json is in gitignore, don't create it, and prune
+# before install to match the behaviour with package-lock.json
 define NPM_INSTALL
 if $(call IS_GIT_IGNORED,package-lock.json); then \
-	npm prune --no-production --no-package-lock && npm install --no-package-lock ;\
+	npm prune --no-production --no-package-lock \
+	&& npm install --no-package-lock ;\
 else \
 	npm install ;\
 fi

--- a/src/tasks/install.mk
+++ b/src/tasks/install.mk
@@ -12,13 +12,18 @@ BOWER_INSTALL = rm -rf bower_components && bower install --config.registry.searc
 # Regular npm install
 node_modules: package.json
 	@if [ -e package-lock.json ]; then rm package-lock.json; fi
-	@if [ -e package.json ]; then mkdir -p node_modules && touch node_modules/.metadata_never_index && $(NPM_INSTALL) && $(DONE); fi
+	@if [ -e package.json ]; then \
+		mkdir -p node_modules && \
+		touch node_modules/.metadata_never_index && \
+		$(NPM_INSTALL) && \
+		$(DONE); \
+	fi
 
 # Regular bower install
 bower_components: bower.json
 	@if [ -e bower.json ]; then $(BOWER_INSTALL) && $(DONE); fi
 
-# These tasks have been intentionally left blank
+# These tasks have been intentionally left blank (why)
 package.json:
 bower.json:
 


### PR DESCRIPTION
- keep current behaviour if package-lock.json is in gitignore
- if not, don't prune before install, and allow it to be created
- remove .metadata_never_index file creation, it [doesn't actually work](https://apple.stackexchange.com/questions/381646/does-metadata-never-index-work-for-keeping-folders-out-of-spotlight-in-catalina) question mark
- drive by cleaning up of unused functions

since the automated tests are only rudimentary "does `make install build` not crash" tests, linking this to a local repo and testing it in a number of scenarios would be appreciated (i've done this myself with `next-article`). instructions:

1. in the repo you're testing, delete `node_modules` and run `npm install ../n-gage` (assuming `n-gage` is in the same parent directory). this will link your local `n-gage` to the repo's `node_modules`, make sure it's on this branch
2. check `make install` runs as usual
3. remove `package-lock.json` from `.gitignore`, and do steps 1 and 2 again
4. check a `package-lock.json` has been created and looks sensible