### PR TITLE
CPP-298 Wait for approval on CircleCI builds from nori and renovate PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,15 +39,15 @@ references:
     branches:
       ignore: master
 
-  filters_only_renovate: &filters_only_renovate
+  filters_only_renovate_nori: &filters_only_renovate_nori
     branches:
-      only: /^renovate-.*/
+      only: /(^renovate-.*|^nori\/.*)/
 
-  filters_ignore_tags_and_renovate: &filters_ignore_tags_and_renovate
+  filters_ignore_tags_renovate_nori: &filters_ignore_tags_renovate_nori
     tags:
       ignore: /.*/
     branches:
-      ignore: /^renovate-.*/
+      ignore: /(^renovate-.*|^nori\/.*)/
 
   filters_version_tag: &filters_version_tag
     tags:
@@ -126,17 +126,17 @@ workflows:
     jobs:
       - build:
           filters:
-            <<: *filters_ignore_tags_and_renovate
+            <<: *filters_ignore_tags_renovate_nori
       - test:
           requires:
             - build
 
-  renovate-build-test:
+  renovate-nori-build-test:
     jobs:
       - waiting-for-approval:
           type: approval
           filters:
-            <<: *filters_only_renovate
+            <<: *filters_only_renovate_nori
       - build:
           requires:
             - waiting-for-approval


### PR DESCRIPTION
Renovate and Nori create many PRs which queue loads of builds in CircleCI blocking other PRs across the entire organisation from building, as a solution we are having PRs created by Renovate and Nori pause from building until approved. <br/><br/>This PR was created using a nori script 🍙<br/><br/>_Nori is a command-line application for managing changes across multiple (usually Github) repositories._