### PR TITLE
Revise install task to use 'npm ci' command

### DIFF
--- a/src/tasks/install.mk
+++ b/src/tasks/install.mk
@@ -7,12 +7,15 @@ instal%: node_modules bower_components dotfiles
 # INSTALL SUB-TASKS
 IS_GIT_IGNORED = grep -q $(if $1, $1, $@) .gitignore
 
-# if package-lock.json is in gitignore, don't create it, and prune
-# before install to match the behaviour with package-lock.json
+# If package-lock.json is in .gitignore, don't create it, and prune before install to match the behaviour with package-lock.json;
+# else if in a CI environment and a package-lock.json exists, use the `npm ci` command to freshly install node_modules from package-lock.json;
+# else run `npm install`.
 define NPM_INSTALL
 if $(call IS_GIT_IGNORED,package-lock.json); then \
 	npm prune --no-production --no-package-lock \
 	&& npm install --no-package-lock ;\
+elif [ ! -z $(CIRCLECI) ] && [ -e package-lock.json ]; then \
+	npm ci ;\
 else \
 	npm install ;\
 fi


### PR DESCRIPTION
Jira card: [CPP-372 make install should use `npm ci` on CI/Heroku if package-lock.json exists](https://financialtimes.atlassian.net/secure/RapidBoard.jspa?rapidView=1051&modal=detail&selectedIssue=CPP-372)

Does it show that I have not written many Make or Shell scripts…? 😬 

I've try to intuit what is going on in this install task and other tasks to see what I can use to fulfil the brief and this is what I have come up with, though it's very easily possible that I have misinterpreted the function of some of those commands I've borrowed.

#### References:
- [Tutorialspoint: Unix / Linux Shell - The if...elif...fi statement](https://www.tutorialspoint.com/unix/if-elif-statement.htm)
- [Linux.org: What does -z flag mean in shell script used in if condition](https://www.linux.org/threads/what-does-z-flag-mean-in-shell-script-used-in-if-condition.17899/#:~:text=In%20both%20cases%2C%20the%20%2Dz,false%20if%20it%20contains%20something.)
- [Stack Overflow: What's the meaning of the parameter -e for bash shell command line?](https://stackoverflow.com/questions/9952177/whats-the-meaning-of-the-parameter-e-for-bash-shell-command-line/9952249#:~:text=The%20%2De%20option%20means%20%22if,%2C%20terminate%20the%20script%20immediately%22.)