### PR TITLE
Upgrade yargs ^10.0.3 -> ^16.0.0 to fix Prototype Pollution

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "stylelint": "^10.0.0",
     "stylelint-order": "^3.0.0",
     "stylelint-scss": "^2.2.0",
-    "yargs": "^10.0.3"
+    "yargs": "^16.0.0"
   },
   "devDependencies": {
     "chai": "^4.1.2",


### PR DESCRIPTION
Jira card: [CPP-397](https://financialtimes.atlassian.net/secure/RapidBoard.jspa?rapidView=1051&modal=detail&selectedIssue=CPP-397&search=n-gage) "n-gage - Address prototype pollution vulnerability"