### PR TITLE
push to HEAD branch

### DIFF
--- a/src/tasks/deploy.mk
+++ b/src/tasks/deploy.mk
@@ -55,7 +55,7 @@ deploy-canary: ## deploy-canary: Deploy canary app to staging
 	nht configure $(VAULT_NAME) $(HEROKU_APP_STAGING)
 
 	@echo "Deploying app to $(HEROKU_APP_STAGING)"
-	@git push https://git.heroku.com/$(HEROKU_APP_STAGING).git master
+	@git push https://git.heroku.com/$(HEROKU_APP_STAGING).git HEAD
 
 	heroku dyno:scale web=1 -a $(HEROKU_APP_STAGING)
 

--- a/src/tasks/deploy.mk
+++ b/src/tasks/deploy.mk
@@ -86,7 +86,7 @@ deploy-staging: ## deploy-staging: Deploy the app to staging
 	nht configure $(VAULT_NAME) $(HEROKU_APP_STAGING)
 
 	@echo "Deploying app to $(HEROKU_APP_STAGING)"
-	@git push https://git.heroku.com/$(HEROKU_APP_STAGING).git master
+	@git push https://git.heroku.com/$(HEROKU_APP_STAGING).git HEAD
 
 	heroku dyno:scale web=1 -a $(HEROKU_APP_STAGING)
 

--- a/src/tasks/review-app.mk
+++ b/src/tasks/review-app.mk
@@ -38,8 +38,8 @@ test-review-ap%: ## test-review-app: Create and test a review app on heroku
 	$(MAKE) gtg-review-app
 	TEST_URL="https://$$(cat $(REVIEW_APP_FILE)).herokuapp.com" \
 		$(MAKE) smoke a11y
-	# Destroy review app if it passes tests on the master branch
-ifeq ($(CIRCLE_BRANCH),master)
+	# Destroy review app if it passes tests on the HEAD branch
+ifeq ($(CIRCLE_BRANCH),HEAD)
 	heroku destroy -a $$(cat $(REVIEW_APP_FILE)) --confirm $$(cat $(REVIEW_APP_FILE))
 endif
 	@$(DONE)


### PR DESCRIPTION
to support colleagues migrating their branches to MAIN

This should pull the code from whichever branch has been set as the default on Github, likely to be `main` or, pre-migration, `master.