### PR TITLE
Force globs to respect Git wildcard characters

### DIFF
--- a/src/setup.mk
+++ b/src/setup.mk
@@ -33,7 +33,7 @@ endif
 #
 
 # misc/legacy
-GLOB = git ls-files -z $1 | tr '\0' '\n' | xargs -I {} find {} ! -type l
+GLOB = GIT_LITERAL_PATHSPECS=0 git ls-files -z $1 | tr '\0' '\n' | xargs -I {} find {} ! -type l
 
 JSON_GET_VALUE = grep $1 | head -n 1 | sed 's/[," ]//g' | cut -d : -f 2
 APP_NAME = $(shell cat package.json 2>/dev/null | $(call JSON_GET_VALUE,name))


### PR DESCRIPTION
### Context
I found this bug after I started making some commits last week and after a while realised that the `pre-commit` hook defined in the project didn't seem to be running as running `make verify` was failing but I was still able to make commits. It turned out that the githook _was_ running fine but when committing from my git client ([magit](https://magit.vc)) it would not print the `eslint` errors I was seeing when running `make verify` in the terminal...
### Description
Previously, if you were using the `GLOB` function in a githook and had passed `--literal-pathspecs` to the `git` command that was hooked (as magit does [by default](https://magit.vc/manual/magit/My-Git-hooks-work-on-the-command_002dline-but-not-inside-Magit.html) for all `git` commands,) Git would automatically set `GIT_LITERAL_PATHSPECS` to 1, meaning further `git` invocations would treat the wildcard characters * and ? as literals, breaking globbing behaviour. Let's force the variable off as we never want it enabled when globbing.
### Breaking Changes
Fixing this bug might mean other developers who are using git clients that set `--literal-pathspecs` will start getting githook errors where previously they were getting false negatives. Obviously, this is the correct behaviour but it might be disruptive. The `GLOB` function is only called from linter code so shouldn't have any other effects beyond githook failures.