### PR TITLE
Install npm 7 in test step in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,8 @@ jobs:
     <<: *container_config_node
     steps:
       - *attach_workspace
+      - node/install-npm:
+          version: "7"
       - run:
           name: Run tests
           command: make test


### PR DESCRIPTION
The npm binary isn't persisted between jobs in a workflow but we don't usually need npm in the test job so it's not an issue. We do for n-gage however, as we're running npm installs in the integration tests.