### PR TITLE
Don't run npm update in Heroku postbuild task

### DIFF
--- a/src/tasks/deploy.mk
+++ b/src/tasks/deploy.mk
@@ -131,7 +131,6 @@ change-api:
 	@$(DONE)
 
 heroku-postbuil%:
-	npm update
 	@if [ -e bower.json ]; then $(BOWER_INSTALL); fi
 	make build-production
 	make deploy-assets


### PR DESCRIPTION
`heroku-postbuild` is a task that is typically called via a `heroku-postbuild` script in the project's `package.json`, which will be called during a Heroku build after the main build script has run. One command in the task is `npm update`. Since [npm 8.3.2](https://github.com/npm/cli/releases/tag/v8.3.2), this command will now automatically prune dev dependencies if running in a production Node environment (it's unclear if this was a conscious change.) This means that subsequent steps in the task fail as n-gage has been pruned prematurely.

I don't think we really want to be running `npm update` after we've build the Heroku app anyway, especially now that we have lockfiles in most projects.